### PR TITLE
Bring in the latest from TC, + other refactoring.

### DIFF
--- a/etc/paracharts.api.md
+++ b/etc/paracharts.api.md
@@ -7,21 +7,29 @@
 import { LitElement } from 'lit';
 import { Manifest } from '@fizz/paramanifest';
 import { PropertyValues } from 'lit';
+import { Size2d } from '@fizz/chart-classifier-utils';
+import { State } from '@lit-app/state';
+import { StateController } from '@lit-app/state';
 import { TemplateResult } from 'lit';
+import { XyPoint } from '@fizz/paramanifest';
 
+// Warning: (ae-forgotten-export) The symbol "ParaChart_base" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export class ParaChart extends LitElement {
+export class ParaChart extends ParaChart_base {
     constructor();
     // (undocumented)
-    dataState: 'initial' | 'pending' | 'complete' | 'error';
+    connectedCallback(): void;
     // (undocumented)
     accessor filename: string;
     // (undocumented)
+    protected firstUpdated(_changedProperties: PropertyValues): void;
+    // (undocumented)
     render(): TemplateResult;
+    // Warning: (ae-forgotten-export) The symbol "ParaStore" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    runloader(): Promise<void>;
-    // (undocumented)
-    setManifest(manifest: Manifest): void;
+    protected _state: StateController<ParaStore>;
     // (undocumented)
     willUpdate(changedProperties: PropertyValues<this>): void;
 }

--- a/lib/common/axisinfo.ts
+++ b/lib/common/axisinfo.ts
@@ -1,0 +1,126 @@
+
+import { ParaStore } from '../store/parastore';
+import { formatBox, formatDatapointX } from '../view_temp/formatter';
+
+import Decimal from 'decimal.js';
+
+export type Tier = string[];
+export interface ChildTierItem {
+  label: string;
+  parent: number;
+}
+export type ChildTier = ChildTierItem[];
+
+export interface AxisOptions {
+  xValues?: readonly number[];
+  yValues: readonly number[];
+  yMin?: number;
+  yMax?: number;
+  // *tiers[0] cannot be a ChildTier
+  xTiers?: (Tier | ChildTier)[];
+  yTiers?: (Tier | ChildTier)[];
+  // Are datapoint views drawn on ticks (false) or between them (true)?
+  isXInterval?: boolean;
+  isYInterval?: boolean;
+}
+
+export interface AxisLabelInfo {
+  min?: number;
+  max?: number;
+  range?: number;
+  labelTiers: (Tier | ChildTier)[];
+}
+
+function computeLabels(
+    start: number, end: number, isPercent: boolean, isGrouping = true
+  ): AxisLabelInfo {
+    const minDec = new Decimal(start);
+    const maxDec = new Decimal(end);
+    const diff = maxDec.sub(minDec);
+    const interval = diff.div(10);
+    let quantizedInterval: Decimal, quantizedMin: Decimal, quantizedMax: Decimal;
+    quantizedInterval = new Decimal(10).pow(interval.log(10).ceil());
+    if (quantizedInterval.div(diff).gte(0.8)) {
+      quantizedInterval = quantizedInterval.div(10);
+    } else if (quantizedInterval.div(diff).gte(0.5)) {
+      quantizedInterval = quantizedInterval.div(4);
+    } else if (quantizedInterval.div(diff).gte(0.2)) {
+      quantizedInterval = quantizedInterval.div(2);
+    }
+    quantizedMin = minDec.div(quantizedInterval).floor().mul(quantizedInterval);
+    quantizedMax = maxDec.div(quantizedInterval).ceil().mul(quantizedInterval);
+    const fmt = new Intl.NumberFormat(undefined, { maximumFractionDigits: 5, useGrouping: isGrouping });
+    const labels = new Array(quantizedMax.sub(quantizedMin).div(quantizedInterval).toNumber() + 1)
+      .fill(0)
+      .map((_, i) => fmt.format(+quantizedMin.add(quantizedInterval.mul(i))) + (isPercent ? '%' : ''));
+    return {
+      min: quantizedMin.toNumber(),
+      max: quantizedMax.toNumber(),
+      range: quantizedMax.sub(quantizedMin).toNumber(),
+      labelTiers: [labels],
+    };
+  }
+
+export class AxisInfo {
+  protected _xLabelInfo!: AxisLabelInfo;
+  protected _yLabelInfo!: AxisLabelInfo; 
+
+  constructor(protected _store: ParaStore, protected _options: AxisOptions) {
+    if (_options.xTiers) {
+      this._xLabelInfo = {labelTiers: _options.xTiers};
+    } else {
+      this._computeXLabelInfo();
+    }
+    if (_options.yTiers) {
+      this._yLabelInfo = {labelTiers: _options.yTiers}
+    } else {
+      this._computeYLabelInfo();
+    }
+  }
+
+  get xLabelInfo() {
+    return this._xLabelInfo;
+  }
+
+  get yLabelInfo() {
+    return this._yLabelInfo;
+  }
+
+  get options() {
+    return this._options;
+  }
+
+  protected _computeXLabels(xMin: number, xMax: number) {
+    return computeLabels(
+      this._store.settings.axis.x.minValue ?? xMin, 
+      this._store.settings.axis.x.maxValue ?? xMax,
+      false);
+  }
+
+  protected _computeYLabels(yMin: number, yMax: number) {
+    return computeLabels(
+      this._store.settings.axis.y.minValue ?? yMin, 
+      this._store.settings.axis.y.maxValue ?? yMax, 
+      false); //this._model.depFormat === 'percent');  
+  }  
+
+  protected _computeXLabelInfo() {
+    if (this._options.xValues) {
+      this._xLabelInfo = this._computeXLabels(
+        Math.min(...this._options.xValues),
+        Math.max(...this._options.xValues));
+    } else {
+      const labels = this._store.model!.boxedXs.map(x => formatBox(x, 'xTick', this._store));
+      this._xLabelInfo = {
+        labelTiers: [labels]
+      };
+    }
+  }
+
+  protected _computeYLabelInfo() {
+    this._yLabelInfo = this._computeYLabels(
+      this._options.yMin ?? Math.min(...this._options.yValues),
+      this._options.yMax ?? Math.max(...this._options.yValues));
+  }
+
+}

--- a/lib/common/logger.ts
+++ b/lib/common/logger.ts
@@ -1,0 +1,26 @@
+
+
+type Constructor<T = {}> = new (...args: any[]) => T;
+
+export type Loggable = Constructor<{ logName(): string }>;
+
+/**
+ * @public
+ */
+export function logging<TBase extends Loggable>(Base: TBase) {
+  return class _logging extends Base {
+
+    log(...data: any[]) {
+      //if (todo().debug) {
+        console.log(`[${this.logName()}]`, ...data);
+      //}
+    }
+
+  };
+}
+
+export const Logger = logging(class {
+  logName() {
+    return 'LOGNAME';
+  }
+});

--- a/lib/paracomponent.ts
+++ b/lib/paracomponent.ts
@@ -1,0 +1,22 @@
+
+import { type ParaController } from './paracontroller';
+
+import { LitElement } from 'lit';
+
+export class ParaComponent extends LitElement {
+
+  protected _controller!: ParaController;
+
+  get controller() {
+    return this._controller;
+  }
+
+  logName() {
+    return this.nodeName;
+  }
+
+  set controller(controller: ParaController) {
+    this._controller = controller;
+  }
+
+}

--- a/lib/paracontroller.ts
+++ b/lib/paracontroller.ts
@@ -1,0 +1,76 @@
+
+import { SignalManager } from './view_temp/signals';
+import { Logger } from './common/logger';
+import { ParaStore } from './store/parastore';
+import { ParaLoader } from "./loader/paraloader";
+import { DeepReadonly, Settings, SettingsInput } from "./store/settings_types";
+import { AllSeriesData } from "./common/types";
+
+import { Manifest } from "@fizz/paramanifest";
+
+export class ParaController extends Logger {
+
+  protected _signalManager = new SignalManager();
+  protected _manifest?: Manifest;
+  protected _store: ParaStore;
+  protected _loader = new ParaLoader();
+  protected _inputSettings: SettingsInput = {};
+  protected _data?: AllSeriesData;
+  protected _suppleteSettingsWith?: DeepReadonly<Settings>;  
+  
+  constructor() {
+    super();
+    this._store = new ParaStore(this._inputSettings, this._suppleteSettingsWith);
+    this.flow();
+  }
+
+  get store() {
+    return this._store;
+  }
+
+  get signalManager() {
+    return this._signalManager;
+  }
+
+  logName() {
+    return 'CONTROLLER';
+  }
+
+  async flow() {
+    this.log('initializing flow');
+    await this._signalManager.pending('connect');
+    this.log('para-chart connected');
+    await this._signalManager.pending('firstUpdate');
+    this.log('para-chart first updated');
+    await this._signalManager.pending('paraviewReady'); //, 'controlPanelReady', 'slotChange');
+    this.log('dom ready');
+    while (true) {
+      const filename = await this._signalManager.pending('dataUpdate');
+      this.runLoader(filename);
+      //await this._signalManager.pending('canvasDataLoadComplete'); //, 'controlPanelDataLoadComplete');
+      await this._signalManager.pending('dataLoadComplete');
+      this.log('ParaCharts will now commence the raising of the roof and/or the dead');
+    }
+  }
+
+  protected _setManifest(manifest: Manifest): void {
+    this._manifest = manifest;
+    this._store.setManifest(manifest);
+  }
+
+  async runLoader(filename: string): Promise<void> {
+    this.log(`loading filename: '${filename}'`);
+    this._store.dataState = 'pending';
+    const loadresult = await this._loader.load('fizz-chart-data', filename);
+    this.log('loaded manifest')
+    if (loadresult.result === 'success') {
+      this._setManifest(loadresult.manifest);
+      this._store.dataState = 'complete';
+      this._signalManager.signal('dataLoadComplete');
+    } else {
+      console.error(loadresult.error);
+      this._store.dataState = 'error';
+    }
+  }
+  
+}

--- a/lib/store/model2D.ts
+++ b/lib/store/model2D.ts
@@ -353,7 +353,11 @@ export class Model2D<X extends Datatype> {
       this[seriesIndex] = aSeries;
       this.keyMap[aSeries.key] = aSeries;
     }
-    this.xs = mergeUnique(...this.series.map((series) => series.xs));
+    this.xs = mergeUniqueBy(
+      (lhs, rhs) => xDatatype === 'date'
+        ? calendarEquals(lhs as CalendarPeriod, rhs as CalendarPeriod)
+        : lhs === rhs,
+      ...this.series.map((series) => series.xs));
     this.ys = mergeUnique(...this.series.map((series) => series.ys));
     this.boxedXs = mergeUniqueBy(
       (lhs: Box<X>, rhs: Box<X>) => lhs.raw === rhs.raw,

--- a/lib/store/series_properties.ts
+++ b/lib/store/series_properties.ts
@@ -22,7 +22,7 @@ export class SeriesPropertyManager {
   private seriesList: SeriesProperties[];
 
   constructor(private store: ParaStore) {
-    this.seriesList = store.model.series.map((series, i) => 
+    this.seriesList = store.model!.series.map((series, i) => 
       new SeriesProperties(series.key, store.colors.colorIndex(i), store.symbols.symbolAt(i)));
   }
 

--- a/lib/store/settings_defaults.ts
+++ b/lib/store/settings_defaults.ts
@@ -78,6 +78,7 @@ export const defaults: Settings = {
         tickLabel: {
           angle: -45,
           offsetPadding: 8,
+          gap: 0
         },
         step: 1
       },
@@ -106,6 +107,7 @@ export const defaults: Settings = {
         tickLabel: {
           angle: 0,
           offsetPadding: 0,
+          gap: 0
         },
         step: 1,
       },

--- a/lib/store/settings_types.ts
+++ b/lib/store/settings_types.ts
@@ -149,6 +149,7 @@ export type LabelFormat = 'raw' | string;
 export interface TickLabelSettings extends SettingGroup {
   angle: number;
   offsetPadding: number;
+  gap: number;
 }
 
 /** @public */

--- a/lib/view_temp/axisline.ts
+++ b/lib/view_temp/axisline.ts
@@ -25,8 +25,17 @@ import { svg } from 'lit';
  */
 export abstract class AxisLine<T extends AxisOrientation> extends View {
 
-  constructor(public readonly axis: Axis<T>) {
+  constructor(public readonly axis: Axis<T>, length: number) {
     super(axis.paraview);
+    this.length = length;
+  }
+
+  get length() {
+    return 0;
+  }
+
+  set length(length: number) {
+
   }
 
   protected abstract getLineD(): string;
@@ -55,14 +64,13 @@ export abstract class AxisLine<T extends AxisOrientation> extends View {
  */
 export class HorizAxisLine extends AxisLine<'horiz'> {
 
-  get width() {
-    // NB: The overhang doesn't count toward the width
-    return this.axis.chartLayers.orientation === 'north' || this.axis.chartLayers.orientation === 'south' ? 
-      this.axis.chartLayers.contentWidth : this.axis.chartLayers.physWidth;
+  get length() {
+    return this.width;
   }
 
-  get height() {
-    return 0;   
+  set length(length: number) {
+    this.width = length;
+    super.length = length;
   }
   
   protected getLineD() {
@@ -83,14 +91,13 @@ export class HorizAxisLine extends AxisLine<'horiz'> {
  */
 export class VertAxisLine extends AxisLine<'vert'> {
 
-  get width() {
-    return 0;
+  get length() {
+    return this.height;
   }
 
-  get height() {
-    // NB: The overhang doesn't count toward the height
-    return this.axis.chartLayers.orientation === 'east' || this.axis.chartLayers.orientation === 'west' ? 
-      this.axis.chartLayers.contentWidth : this.axis.chartLayers.physHeight;
+  set length(length: number) {
+    this.height = length;
+    super.length = length;
   }
 
   protected getLineD() {

--- a/lib/view_temp/base_view.ts
+++ b/lib/view_temp/base_view.ts
@@ -132,6 +132,11 @@ export class View extends BaseView {
     return this._id;
   }
 
+  set id(id: string) {
+    this._id = id;
+    this.paraview.requestUpdate();
+  }
+
   get parent() {
     return this._parent;
   }

--- a/lib/view_temp/label.ts
+++ b/lib/view_temp/label.ts
@@ -68,7 +68,7 @@ export class Label extends View {
     this._textAnchor = this.options.textAnchor ?? options.wrapWidth ? 'start' : 'middle';
     this._justify = this.options.justify ?? 'start';
     this._text = this.options.text;
-    this.computeSize();
+    //this.computeSize();
   }
 
   protected _createId() {
@@ -121,7 +121,7 @@ export class Label extends View {
 
   set textAnchor(textAnchor: LabelTextAnchor) {
     this._textAnchor = textAnchor;
-    //this._updateSize();
+    this.updateSize();
   }
 
   get bbox() {
@@ -151,7 +151,8 @@ export class Label extends View {
       text.setAttribute('transform', `rotate(${this._angle})`);
     }
     // WAS `root`
-    this.paraview.renderRoot!.append(text);
+    //this.paraview.renderRoot!.append(text);
+    this.paraview.root!.append(text);
 
     /* WAS `root`
     if (!this.paraview.root) {
@@ -218,7 +219,6 @@ export class Label extends View {
   private makeTransform() {
     let t: string | undefined;
     if (this._angle) {
-      console.log('mt', this._x, this._anchorXOffset, this._y, this._anchorYOffset)
       t = fixed`
         translate(${this._x + this._anchorXOffset},${this._y + this._anchorYOffset})
         rotate(${this._angle})
@@ -230,7 +230,6 @@ export class Label extends View {
   render() {
     // TODO: figure out why `this._y` is larger here than for single line titles
     // HACK: divide `this._y` by 2 for `y` attribute value
-    console.log('r', this._x, this._anchorXOffset, this._y, this._anchorYOffset)
     return svg`
       <text 
         ${ref(this._elRef)}

--- a/lib/view_temp/line.ts
+++ b/lib/view_temp/line.ts
@@ -134,12 +134,12 @@ export class LineSection extends ChartPoint {
       // find midpoint x position
       this._prevMidX = this._x - LineSection.width/2; // - 0.1;
       // pixel height/y-value range
-      const pxPerYUnit = this.chart.height/this.chart.yLabelInfo.range!;
+      const pxPerYUnit = this.chart.height/this.chart.axisInfo!.yLabelInfo.range!;
       // find midpoint y position
       const prevValue = this._prev!.datapoint.y;
       const prevMidDiff = Math.min(this.datapoint.y, prevValue) + 
         (Math.max(this.datapoint.y, prevValue) - Math.min(this.datapoint.y, prevValue))/2;
-      const prevMidHeight = (prevMidDiff - this.chart.yLabelInfo.min!)*pxPerYUnit;
+      const prevMidHeight = (prevMidDiff - this.chart.axisInfo!.yLabelInfo.min!)*pxPerYUnit;
       this._prevMidY = this.chart.height - prevMidHeight;
   }
 
@@ -147,12 +147,12 @@ export class LineSection extends ChartPoint {
       // find midpoint x position
       this._nextMidX = this._x + LineSection.width/2; // + 0.1;
       // pixel height/y-value range
-      const pxPerYUnit = this.chart.height/this.chart.yLabelInfo.range!;
+      const pxPerYUnit = this.chart.height/this.chart.axisInfo!.yLabelInfo.range!;
       // find midpoint y position
       const nextValue = this._next!.datapoint.y;
       const nextMidDiff = Math.min(this.datapoint.y, nextValue) + 
         (Math.max(this.datapoint.y, nextValue) - Math.min(this.datapoint.y, nextValue))/2;
-      const nextMidHeight = (nextMidDiff - this.chart.yLabelInfo.min!)*pxPerYUnit;
+      const nextMidHeight = (nextMidDiff - this.chart.axisInfo!.yLabelInfo.min!)*pxPerYUnit;
 
       this._nextMidY = this.chart.height - nextMidHeight;
   }

--- a/lib/view_temp/pointchart.ts
+++ b/lib/view_temp/pointchart.ts
@@ -15,9 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 
 import { XYChart, XYDatapointView, XYSeriesView } from './xychart';
-import { Axis, type AxisOrientation } from './axis';
-import { type TickLabelTier, HorizTickLabelTier, VertTickLabelTier } from './ticklabeltier';
-//import { utils, fixed } from '../utilities';
+import { AxisInfo } from '../common/axisinfo';
 import { type PointChartType } from '../store/settings_types';
 import { dedupPrimitive, enumerate, strToId } from '../common/utils';
 import { formatBox, formatDatapoint, formatDatapointX } from './formatter';
@@ -29,23 +27,16 @@ import { type coord, generateClusterAnalysis } from '@fizz/clustering';
  * (connected or not).
  */
 export abstract class PointChart extends XYChart {
-
-  protected _tickIntervalX!: number;
-  protected _tickIntervalY!: number;
-  protected _isComputeXTicks = false;
-
-  private selectors: string[][] = [];
  
   protected _addedToParent() {
     super._addedToParent();
+    this._axisInfo = new AxisInfo(this.paraview.store, {
+      yValues: this.paraview.store.model!.ys
+    });
   }
 
   get datapointViews() {
     return super.datapointViews as ChartPoint[];
-  }
-
-  get isComputeXTicks(): boolean {
-    return this._isComputeXTicks;
   }
 
   protected _newDatapointView(seriesView: XYSeriesView) {
@@ -54,15 +45,15 @@ export abstract class PointChart extends XYChart {
 
   protected _createComponents() {
     const xs: string[] = [];
-    for (const [x, i] of enumerate(this.paraview.store.model.boxedXs)) {
+    for (const [x, i] of enumerate(this.paraview.store.model!.boxedXs)) {
       xs.push(formatBox(x, `${this.parent.docView.type as PointChartType}Point`, this.paraview.store));
       const xId = strToId(xs.at(-1)!);
-      if (this.selectors[i] === undefined) {
-        this.selectors[i] = [];
-      }
-      this.selectors[i].push(`tick-x-${xId}`);
+      // if (this.selectors[i] === undefined) {
+      //   this.selectors[i] = [];
+      // }
+      // this.selectors[i].push(`tick-x-${xId}`);
     }
-    for (const [col, i] of enumerate(this.paraview.store.model.series)) {
+    for (const [col, i] of enumerate(this.paraview.store.model!.series)) {
       const seriesView = new XYSeriesView(this, col.key);
       this._chartLandingView.append(seriesView);
       for (const [value, j] of enumerate(col)) {
@@ -84,101 +75,22 @@ export abstract class PointChart extends XYChart {
     this._layoutSymbols();
   }
 
-  protected _computeXLabelInfo() {
-    if (this._isComputeXTicks) {
-      const values = this.paraview.store.model.xs as number[];
-      this._xLabelInfo = Axis.computeNumericLabels(
-        this.paraview.store.settings.axis.x.minValue ?? Math.min(...values), 
-        this.paraview.store.settings.axis.x.maxValue ?? Math.max(...values),
-        false);
-    } else {
-      const datapoints = this.paraview.store.model.allPoints;
-      const labels = dedupPrimitive(datapoints.map(point => formatDatapointX(point, 'xTick', this.paraview.store)));
-      this._xLabelInfo = {
-        labels,
-        maxChars: Math.max(...labels.map(l => l.length))
-      };
-    }
-  }
-
-  protected _computeYLabelInfo() {
-    const values = this.paraview.store.model.ys;
-    this._yLabelInfo = Axis.computeNumericLabels(
-      this.paraview.store.settings.axis.y.minValue ?? Math.min(...values), 
-      this.paraview.store.settings.axis.y.maxValue ??  Math.max(...values), 
-      false /*this._model.depFormat === 'percent'*/);  
-  }
-
   protected _layoutDatapoints() {
-    this._tickIntervalX = this.parent.contentWidth/(this._xLabelInfo.labels.length - 1);
-    this._tickIntervalY = this.height/(this._yLabelInfo.labels.length - 1);
-    //this.updateGrid(this.tickIntervalY, this.tickIntervalX);
     ChartPoint.computeSize(this);
     for (const datapointView of this.datapointViews) {
        datapointView.computeLayout();
     }
   }
 
-  getXTickLabelTiers<T extends AxisOrientation>(axis: Axis<T>): TickLabelTier<any>[] {
-    //const xSeries = this.paraview.store.model.xs;
-    const slots = this._xLabelInfo.labels.map((tickLabel, i) => 
-      ({
-        pos: this._tickIntervalX*i,
-        text: tickLabel,
-        id: this.selectors[i][0]
-      }));
-    if (axis.isHoriz()) {
-      return [new HorizTickLabelTier(
-        axis,
-        slots,
-        this._tickIntervalX,
-        this.paraview
-      )];
-    } else if (axis.isVert()) {
-      return [new VertTickLabelTier(
-        axis,
-        slots,
-        this._tickIntervalX,
-        this.paraview
-      )];
-    } else {
-      throw new Error('impossible axis orientation!');
-    }
-  }
-
-  getYTickLabelTiers<T extends AxisOrientation>(axis: Axis<T>): TickLabelTier<any>[] {
-    const slots = this._yLabelInfo.labels.map((tickLabel, i) => 
-      ({
-        pos: this._tickIntervalY*i,
-        text: tickLabel,
-        id: `tick-y-${strToId(tickLabel)}`
-      }));
-    if (axis.isHoriz()) {
-      return [new HorizTickLabelTier(
-        axis,
-        slots,
-        this._tickIntervalY,
-        this.paraview
-      )];
-    } else if (axis.isVert()) {
-      return [new VertTickLabelTier(
-        axis,
-        slots,
-        this._tickIntervalY,
-        this.paraview
-      )];
-    } else {
-      throw new Error('impossible axis orientation!');
-    }
-  }
-
-  /*protected _generateClustering(){
-    const data: coord[] = []
-    for (let i = 0; i < this._model.data.data[0].data.length; i++){
-      data.push({x: Number(this._model.data.data[0].data[i]), y: Number(this._model.data.data[1].data[i])})
-    }
+  protected _generateClustering(){
+    const data: Array<coord> = []
+    const yValues = this.paraview.store.model!.ys;
+    const xValues = this.paraview.store.model!.xs as number[];
+    for (let i = 0; i < xValues.length; i++){
+      data.push({x: xValues[i], y: yValues[i]})
+    } 
     this._clustering = generateClusterAnalysis(data, true);
-  }*/
+  } 
 
   seriesRef(series: string) {
     return this.paraview.ref<SVGGElement>(`series.${series}`);
@@ -190,7 +102,7 @@ export abstract class PointChart extends XYChart {
   }
 
   getDatapointGroupBbox(labelText: string) {
-    const labels = this.paraview.store.model.boxedXs.map((box) => formatBox(box, 'xTick', this.paraview.store));
+    const labels = this.paraview.store.model!.boxedXs.map((box) => formatBox(box, 'xTick', this.paraview.store));
     const idx = labels.findIndex(label => label === labelText);
     if (idx === -1) {
       throw new Error(`no such datapoint with label '${labelText}'`);
@@ -215,7 +127,7 @@ export class ChartPoint extends XYDatapointView {
   static width: number;
 
   static computeSize(chart: PointChart) {
-    const axisDivisions = chart.paraview.store.model.numSeries;
+    const axisDivisions = chart.paraview.store.model!.xs.length - 1;
     this.width = chart.parent.contentWidth/axisDivisions;
   }
 
@@ -243,26 +155,18 @@ export class ChartPoint extends XYDatapointView {
     return 'scale(1.5)';
   }
 
-  computeLayout() {
-    const ylabelInfo = this.chart.yLabelInfo;
-    const xlabelInfo = this.chart.xLabelInfo;
-    const canvasHeightPx = this.chart.height;
-    // pixel height/y-value range
-    const pxPerYUnit = canvasHeightPx / ylabelInfo.range!;
-    // height (= distance from x-axis) in pixels
-    const height = (this.datapoint.y - ylabelInfo.min!) * pxPerYUnit;
-    // pixels above the datapoint
+  protected _computeX() {
+    return ChartPoint.width * this.index;
+  }
 
-    //Scales points in proportion to the data range, should only activate for scatterplots
-    if (this.chart.isComputeXTicks){
-      const xTemp: number = (Number(this.datapoint.xRaw) - Number(xlabelInfo.min!)) / Number(xlabelInfo.range!);
-      const parentWidth: number = this.chart.parent.contentWidth;
-      this._x = parentWidth * xTemp;
-    }
-    else {
-      this._x = ChartPoint.width * this.index;
-    }
-    this._y = canvasHeightPx - height;
+  protected _computeY() {
+    const pxPerYUnit = this.chart.height / this.chart.axisInfo!.yLabelInfo.range!;
+    return this.chart.height - (this.datapoint.y as number - this.chart.axisInfo!. yLabelInfo.min!) * pxPerYUnit;
+  }
+
+  computeLayout() {
+    this._x = this._computeX();
+    this._y = this._computeY();
   }
 
 }

--- a/lib/view_temp/scatter.ts
+++ b/lib/view_temp/scatter.ts
@@ -3,6 +3,7 @@ import { PointChart, ChartPoint } from './pointchart';
 import { type ScatterSettings, Setting, type DeepReadonly } from '../store/settings_types';
 import { type XYSeriesView } from './xychart';
 import { ParaView } from './paraview';
+import { AxisInfo } from '../common/axisinfo';
 
 export class ScatterPlot extends PointChart {
 
@@ -10,10 +11,7 @@ export class ScatterPlot extends PointChart {
   
   constructor(index: number, paraview: ParaView) {
     super(index, paraview);
-    this._isComputeXTicks = true;
-
     this._isClustering = true;
-
   }
 
   get settings() {
@@ -24,6 +22,14 @@ export class ScatterPlot extends PointChart {
     return false;
   }
 
+  protected _addedToParent(): void {
+    super._addedToParent();
+    this._axisInfo = new AxisInfo(this.paraview.store, {
+      xValues: this.paraview.store.model!.xs as number[],
+      yValues: this.paraview.store.model!.ys
+    });
+  }
+
   protected _newDatapointView(seriesView: XYSeriesView) {
     return new ScatterPoint(seriesView);
   }
@@ -31,5 +37,11 @@ export class ScatterPlot extends PointChart {
 }
 
 class ScatterPoint extends ChartPoint {
+  protected _computeX() {
+    // Scales points in proportion to the data range
+    const xTemp = (this.datapoint.x as number - this.chart.axisInfo!.xLabelInfo.min!) / this.chart.axisInfo!.xLabelInfo.range!;
+    const parentWidth: number = this.chart.parent.contentWidth;
+    return parentWidth * xTemp;
+  }
 }
 

--- a/lib/view_temp/xychart.ts
+++ b/lib/view_temp/xychart.ts
@@ -21,7 +21,6 @@ import {
 import { type Setting } from '../store/settings_types';
 //import { keymaps } from '../input';
 //import { hotkeyActions } from '../input/defaultactions';
-import { Axis, type AxisLabelInfo } from './axis';
 //import { NOTE_LENGTH } from '../audio/sonifier';
 //import { type Actions, type Action } from '../input/actions';
 
@@ -73,8 +72,6 @@ export abstract class XYChart extends DataLayer {
   protected isGrouping = false;
   protected isConnector = false;
   protected maxDatapointSize!: number;
-  protected _xLabelInfo!: AxisLabelInfo;
-  protected _yLabelInfo!: AxisLabelInfo<number>; 
 
   private _isChordModeEnabled = false;
 
@@ -121,14 +118,6 @@ export abstract class XYChart extends DataLayer {
     return this._isChordModeEnabled;
   }
   
-  get xLabelInfo(): Readonly<AxisLabelInfo> {
-    return this._xLabelInfo;
-  }
-
-  get yLabelInfo(): Readonly<AxisLabelInfo<number>> {
-    return this._yLabelInfo;
-  }
-
   set isChordModeEnabled(isChordModeEnabled) {
     this._isChordModeEnabled = isChordModeEnabled;
     this._chartLandingView.focusLeaf.focus();
@@ -184,13 +173,9 @@ export abstract class XYChart extends DataLayer {
 
   protected abstract _newDatapointView(seriesView: XYSeriesView, ...rest: any[]): XYDatapointView;
 
-  protected abstract _computeXLabelInfo(): void;
-  protected abstract _computeYLabelInfo(): void;
   protected abstract _layoutDatapoints(): void;
 
   protected _layoutComponents() {
-    this._computeXLabelInfo();
-    this._computeYLabelInfo();
     this._layoutDatapoints();
   }
 


### PR DESCRIPTION
Lots of changes and fixes here, hopefully nothing too controversial. I've tried to maintain the overall new architecture and one-way data flow as outlined [here](https://github.com/fizzstudio/papacharts/issues/238).

A summary:
- Added `ParaController`. Basically, it runs a state machine that controls the overall operation of the ParaCharts instance, and takes over responsibility for running the loader. In theory, someone could run a headless instance simply by creating an instance of this class, rather than a `para-chart`.
- Ported in the logging mechanism from TodoCharts (although there is no debug-mode variable, yet).
- Components now inherit from `ParaComponent`, which provides a controller field and sets the log name to the element node name.
- The store now only gets created once, and updated with new data as it arrives. This allows settings to persist across data updates, and allows default settings to be accessed earlier in the init process.
- `ParaChart` now always renders the `para-view` unconditionally, and the `para-view` will be responsible for displaying a load screen or error messages (not implemented yet).
- Fixed a bug in the `Model2D` constructor where `CalendarPeriod` x-values weren't getting merged.
- Incorporated recent changes to TodoCharts, including: the `AxisInfo` object; refactored axis classes, which can now auto-resize without needing to recreate the entire doc view; bar charts now cluster their data before creating their components, to facilitate creating an `AxisInfo` object; Sam's clustering updates.

At this point, charts are rendering, but there's still quite a lot of functionality to bring in before we have feature parity with PapaCharts. 