### PR TITLE
Fixed clustering per https://github.com/fizzstudio/ParaCharts/issues/47

### DIFF
--- a/lib/view/data/datapoint.ts
+++ b/lib/view/data/datapoint.ts
@@ -5,7 +5,6 @@ import { type DataPointDF } from '../../store';
 import { strToId } from '../../common/utils';
 import { formatBox } from '../formatter';
 
-import { type clusterObject } from '@fizz/clustering';
 
 import { type StaticValue } from 'lit/static-html.js';
 import { type ClassInfo, classMap } from 'lit/directives/class-map.js';
@@ -158,18 +157,7 @@ export class DatapointView extends DataView {
   protected _createSymbol() {
     const series = this.seriesProps;
     let symbolType = series.symbol;
-    const index = this.parent.children.indexOf(this);
     let color: number = series.color;
-    const types = new DataSymbols().types;
-    if (this.chart.isClustering){ 
-      let clustering = this.chart.clustering as clusterObject[]
-      for (let clusterId in clustering){
-        if (clustering[clusterId].dataPointIDs.indexOf(index) > -1){
-          color = Number(clusterId)
-          symbolType = types[color % types.length]
-        }
-      }
-    }
     this._symbol = DataSymbol.fromType(this.paraview, symbolType, {
       strokeWidth: this.paraview.store.settings.chart.symbolStrokeWidth,
       color

--- a/lib/view/datalayer.ts
+++ b/lib/view/datalayer.ts
@@ -32,7 +32,6 @@ import { type HotkeyEvent } from '../store/keymap_manager';
 import { ChartLandingView, type DataView, type DatapointView } from './data';
 import { type LegendItem } from './legend';
 
-import { type clusterObject } from '@fizz/clustering';
 
 /**
  * @public
@@ -74,8 +73,6 @@ export abstract class DataLayer extends ChartLayer {
   //private _prevDatapointSeries?: string;
   //private _currentRecord = 0;
 
-  protected _isClustering: boolean = false;
-  protected _clustering?: clusterObject[];
 
   constructor(paraview: ParaView, public readonly dataLayerIndex: number) {
     super(paraview);
@@ -136,13 +133,6 @@ export abstract class DataLayer extends ChartLayer {
 
   get datapointViews() {
     return this._chartLandingView.datapointViews;
-  }
-
-  get isClustering(){
-    return this._isClustering;
-  }
-  get clustering(){
-    return this._clustering;
   }
 
   get visitedDatapointViews() {

--- a/lib/view/pointchart.ts
+++ b/lib/view/pointchart.ts
@@ -20,7 +20,6 @@ import { type PointChartType } from '../store/settings_types';
 import { enumerate, strToId } from '../common/utils';
 import { formatBox } from './formatter';
 
-import { type coord, generateClusterAnalysis } from '@fizz/clustering';
 
 /**
  * Abstract base class for charts that represent data values as points
@@ -82,15 +81,6 @@ export abstract class PointChart extends XYChart {
     }
   }
 
-  protected _generateClustering(){
-    const data: Array<coord> = []
-    const yValues = this.paraview.store.model!.allFacetValues('y')!.map((y) => y.value as number);
-    const xValues = this.paraview.store.model!.allFacetValues('x')!.map((y) => y.value as number);
-    for (let i = 0; i < xValues.length; i++){
-      data.push({x: xValues[i], y: yValues[i]});
-    } 
-    this._clustering = generateClusterAnalysis(data, true);
-  } 
 
   seriesRef(series: string) {
     return this.paraview.ref<SVGGElement>(`series.${series}`);

--- a/lib/view/scatter.ts
+++ b/lib/view/scatter.ts
@@ -4,6 +4,7 @@ import { type ScatterSettings, Setting, type DeepReadonly } from '../store/setti
 import { type XYSeriesView } from './xychart';
 import { ParaView } from '../paraview';
 import { AxisInfo } from '../common/axisinfo';
+import { coord, generateClusterAnalysis } from '@fizz/clustering';
 
 export class ScatterPlot extends PointChart {
 
@@ -11,7 +12,12 @@ export class ScatterPlot extends PointChart {
   
   constructor(paraview: ParaView, index: number) {
     super(paraview, index);
-    this._isClustering = true;
+    if (this.paraview.store.model?.numSeries === 1){
+      this._isClustering = true;
+    }
+    else{
+      this._isClustering = false;
+    }
   }
 
   get settings() {
@@ -34,6 +40,23 @@ export class ScatterPlot extends PointChart {
     return new ScatterPoint(seriesView);
   }
 
+  protected _createComponents(): void {
+    if (this.isClustering){
+      this._generateClustering();
+    }
+    super._createComponents()
+  }
+
+  protected _generateClustering(){
+    const data: Array<coord> = []
+    const seriesList = this.paraview.store.model!.series
+    for (let series of seriesList){
+      for (let i = 0; i < series.length; i++){
+        data.push({x: series[i].x.value as number, y: series[i].y.value as number});
+      } 
+    }
+    this._clustering = generateClusterAnalysis(data, true);
+  } 
 }
 
 class ScatterPoint extends ChartPoint {


### PR DESCRIPTION
-Fixes `_generateClustering()` to work with new model
-Moves `_generateClustering()` and associated call from `pointchart.ts` to `scatter.ts`. As long as scatterplots are the only thing using that clustering algorithm it makes more sense to have it there.
-Moves the coloring of datapoint symbols from `datapoint.ts` to `scatter.ts`. This also lets me remove the clustering related properties from `datalayer`
-Only scatterplots with one series have clustering enabled now. For stuff like the Iris dataset, I think we can assume for now that if multiple series are being passed in, those are more important to group by than any generated spatial clusters. I made `_generateClustering()` general enough to handle multiple series if we want to change this in the future.