### PR TITLE
Add donut chart stories

### DIFF
--- a/lib/loader/paraloader.ts
+++ b/lib/loader/paraloader.ts
@@ -1,4 +1,4 @@
-import { Manifest } from "@fizz/paramanifest";
+import { ChartType, Manifest } from "@fizz/paramanifest";
 import { exhaustive } from "../common/utils";
 
 export type SourceKind = 'fizz-chart-data';
@@ -18,13 +18,17 @@ type LoadResult = LoadSuccess | LoadFailure;
 const CHART_DATA_MODULE_PREFIX = './node_modules/@fizz/chart-data/data/';
 
 export class ParaLoader {
-  public async load(kind: SourceKind, filename: string): Promise<LoadResult> {
+  public async load(kind: SourceKind, filename: string, chartType?: ChartType): Promise<LoadResult> {
     if (kind === 'fizz-chart-data') {
       const filePath = CHART_DATA_MODULE_PREFIX + filename;
       console.log(`loading manifest from ${filePath}`)
       const manifestRaw = await fetch(filePath);
       const manifest = await manifestRaw.json() as Manifest;
       console.log('manifest loaded');
+      if (chartType) {
+        manifest.datasets[0].type = chartType;
+        console.log('manifest chart type changed')
+      }
       return { result: 'success', manifest };
     }
     return exhaustive();

--- a/lib/parachart/parachart.ts
+++ b/lib/parachart/parachart.ts
@@ -43,7 +43,7 @@ export class ParaChart extends logging(ParaComponent) {
 
   constructor() {
     super();
-    this._controller = new ParaController(this, this.forcecharttype);
+    this._controller = new ParaController(this);
     // also creates the state controller
     this.store = this._controller.store;
   }

--- a/lib/parachart/parachart.ts
+++ b/lib/parachart/parachart.ts
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 import { logging } from '../common/logger';
 import { ParaComponent } from '../components';
 import { ParaController } from '../paracontroller';
-import { AllSeriesData } from '@fizz/paramanifest'
+import { AllSeriesData, ChartType } from '@fizz/paramanifest'
 import { DeepReadonly, Settings, SettingsInput } from "../store/settings_types";
 import "../paraview";
 import "../control_panel";
@@ -39,9 +39,11 @@ export class ParaChart extends logging(ParaComponent) {
 
   @property() accessor filename = '';
 
+  @property() accessor forcecharttype: ChartType | undefined;
+
   constructor() {
     super();
-    this._controller = new ParaController(this);
+    this._controller = new ParaController(this, this.forcecharttype);
     // also creates the state controller
     this.store = this._controller.store;
   }

--- a/lib/paracontroller.ts
+++ b/lib/paracontroller.ts
@@ -17,7 +17,7 @@ export class ParaController extends Logger {
   protected _data?: AllSeriesData;
   protected _suppleteSettingsWith?: DeepReadonly<Settings>;  
   
-  constructor(parachart: ParaChart, private _forceChartType?: ChartType) {
+  constructor(private parachart: ParaChart) {
     super();
     this._store = new ParaStore(this._inputSettings, this._suppleteSettingsWith);
     parachart.addEventListener('paraviewready', async () => {
@@ -46,7 +46,7 @@ export class ParaController extends Logger {
   async runLoader(filename: string): Promise<void> {
     this.log(`loading filename: '${filename}'`);
     this._store.dataState = 'pending';
-    const loadresult = await this._loader.load('fizz-chart-data', filename, this._forceChartType);
+    const loadresult = await this._loader.load('fizz-chart-data', filename, this.parachart.forcecharttype);
     this.log('loaded manifest')
     if (loadresult.result === 'success') {
       this._setManifest(loadresult.manifest);

--- a/lib/paracontroller.ts
+++ b/lib/paracontroller.ts
@@ -3,7 +3,7 @@ import { Logger } from './common/logger';
 import { ParaStore } from './store/parastore';
 import { ParaLoader } from "./loader/paraloader";
 import { DeepReadonly, Settings, SettingsInput } from "./store/settings_types";
-import { AllSeriesData } from "@fizz/paramanifest";
+import { AllSeriesData, ChartType } from "@fizz/paramanifest";
 import { type ParaChart } from './parachart/parachart';
 
 import { Manifest } from "@fizz/paramanifest";
@@ -17,7 +17,7 @@ export class ParaController extends Logger {
   protected _data?: AllSeriesData;
   protected _suppleteSettingsWith?: DeepReadonly<Settings>;  
   
-  constructor(parachart: ParaChart) {
+  constructor(parachart: ParaChart, private _forceChartType?: ChartType) {
     super();
     this._store = new ParaStore(this._inputSettings, this._suppleteSettingsWith);
     parachart.addEventListener('paraviewready', async () => {
@@ -46,7 +46,7 @@ export class ParaController extends Logger {
   async runLoader(filename: string): Promise<void> {
     this.log(`loading filename: '${filename}'`);
     this._store.dataState = 'pending';
-    const loadresult = await this._loader.load('fizz-chart-data', filename);
+    const loadresult = await this._loader.load('fizz-chart-data', filename, this._forceChartType);
     this.log('loaded manifest')
     if (loadresult.result === 'success') {
       this._setManifest(loadresult.manifest);

--- a/src/stories/Chart.ts
+++ b/src/stories/Chart.ts
@@ -4,17 +4,19 @@ import { type SettingsInput } from '../../lib/store/settings_types';
 
 import { html, nothing } from 'lit';
 import '../../lib';
+import { ChartType } from '@fizz/paramanifest';
 
 export interface ChartProps {
   filename: string;
-  config?: SettingsInput;  
+  config?: SettingsInput;
+  forcecharttype?: ChartType;
 }
 
 /**
  * Primary UI component for user interaction
  */
 export const Chart = ({ 
-  filename, config
+  filename, config, forcecharttype
 }: ChartProps) => {
   return html`
     <style>
@@ -67,6 +69,7 @@ export const Chart = ({
   <para-chart 
     filename=${filename} 
     .config=${config ?? nothing}
+    forcecharttype=${forcecharttype ?? nothing}
   >
     <span slot="settings"></span>
   </para-chart>

--- a/src/stories/allStoriesTemplate.ts
+++ b/src/stories/allStoriesTemplate.ts
@@ -28,6 +28,7 @@ export const %(storyName)s: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "%(chartType)s",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/alldonut.stories.ts
+++ b/src/stories/autogen/alldonut.stories.ts
@@ -1,0 +1,48 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('pastry', false);
+
+const meta = {
+  title: "Chart/Donut Charts",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllDonutCharts: Story = {
+  name: 'All Donut Charts',
+  args: {
+    filename: '',
+    config: { // change to configFile: "./sample_config.json",
+      "ui.colorVisionMode": "deutan"
+    },
+    /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
+      "chart": {
+        "a": {
+          "action": "move_left"
+        },
+        "d": {
+          "action": "move_right"
+        },
+        "w": {
+          "action": "move_up"
+        },
+        "s": {
+          "action": "move_down"
+        }
+      }
+    }*/
+  }
+};

--- a/src/stories/autogen/alldonut.stories.ts
+++ b/src/stories/autogen/alldonut.stories.ts
@@ -28,6 +28,7 @@ export const AllDonutCharts: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "donut",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/allmultibar.stories.ts
+++ b/src/stories/autogen/allmultibar.stories.ts
@@ -28,6 +28,7 @@ export const AllMultiBarCharts: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "bar",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/allmulticolumn.stories.ts
+++ b/src/stories/autogen/allmulticolumn.stories.ts
@@ -28,6 +28,7 @@ export const AllMultiColumnCharts: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "column",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/allmultiline.stories.ts
+++ b/src/stories/autogen/allmultiline.stories.ts
@@ -28,6 +28,7 @@ export const AllMultiLineCharts: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/allmultilollipop.stories.ts
+++ b/src/stories/autogen/allmultilollipop.stories.ts
@@ -28,6 +28,7 @@ export const AllMultiLollipopCharts: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "lollipop",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/allmultistepline.stories.ts
+++ b/src/stories/autogen/allmultistepline.stories.ts
@@ -28,6 +28,7 @@ export const AllMultiSteplineCharts: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/allpie.stories.ts
+++ b/src/stories/autogen/allpie.stories.ts
@@ -28,6 +28,7 @@ export const AllPieCharts: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "pie",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/allscatter.stories.ts
+++ b/src/stories/autogen/allscatter.stories.ts
@@ -28,6 +28,7 @@ export const AllScatterCharts: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "scatter",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/allsinglebar.stories.ts
+++ b/src/stories/autogen/allsinglebar.stories.ts
@@ -28,6 +28,7 @@ export const AllSingleBarCharts: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "bar",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/allsinglecolumn.stories.ts
+++ b/src/stories/autogen/allsinglecolumn.stories.ts
@@ -28,6 +28,7 @@ export const AllSingleColumnCharts: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "column",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/allsingleline.stories.ts
+++ b/src/stories/autogen/allsingleline.stories.ts
@@ -28,6 +28,7 @@ export const AllSingleLineCharts: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/allsinglelollipop.stories.ts
+++ b/src/stories/autogen/allsinglelollipop.stories.ts
@@ -28,6 +28,7 @@ export const AllSingleLollipopCharts: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "lollipop",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/allsinglestepline.stories.ts
+++ b/src/stories/autogen/allsinglestepline.stories.ts
@@ -28,6 +28,7 @@ export const AllSingleSteplineCharts: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/barMulti0.stories.ts
+++ b/src/stories/autogen/barMulti0.stories.ts
@@ -18,6 +18,7 @@ export const Chart0: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "bar",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/barSingle1.stories.ts
+++ b/src/stories/autogen/barSingle1.stories.ts
@@ -18,6 +18,7 @@ export const Chart1: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "bar",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/columnMulti0.stories.ts
+++ b/src/stories/autogen/columnMulti0.stories.ts
@@ -18,6 +18,7 @@ export const Chart0: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "column",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/columnSingle1.stories.ts
+++ b/src/stories/autogen/columnSingle1.stories.ts
@@ -18,6 +18,7 @@ export const Chart1: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "column",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/donut40.stories.ts
+++ b/src/stories/autogen/donut40.stories.ts
@@ -18,6 +18,7 @@ export const Chart40: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "donut",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/donut40.stories.ts
+++ b/src/stories/autogen/donut40.stories.ts
@@ -1,0 +1,38 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Chart/Donut Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart40: Story = {
+  name: "Division of energy in the Universe (40)",
+  args: {
+    filename: "manifests/pie-manifest-dark-matter.json",
+    config: { // change to configFile: "./sample_config.json",
+      "ui.colorVisionMode": "deutan"
+    },
+    /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
+      "chart": {
+        "a": {
+          "action": "move_left"
+        },
+        "d": {
+          "action": "move_right"
+        },
+        "w": {
+          "action": "move_up"
+        },
+        "s": {
+          "action": "move_down"
+        }
+      }
+    },*/
+  }
+}

--- a/src/stories/autogen/lineMulti10.stories.ts
+++ b/src/stories/autogen/lineMulti10.stories.ts
@@ -18,6 +18,7 @@ export const Chart10: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineMulti11.stories.ts
+++ b/src/stories/autogen/lineMulti11.stories.ts
@@ -18,6 +18,7 @@ export const Chart11: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineMulti2.stories.ts
+++ b/src/stories/autogen/lineMulti2.stories.ts
@@ -18,6 +18,7 @@ export const Chart2: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineMulti3.stories.ts
+++ b/src/stories/autogen/lineMulti3.stories.ts
@@ -18,6 +18,7 @@ export const Chart3: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineMulti4.stories.ts
+++ b/src/stories/autogen/lineMulti4.stories.ts
@@ -18,6 +18,7 @@ export const Chart4: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineMulti5.stories.ts
+++ b/src/stories/autogen/lineMulti5.stories.ts
@@ -18,6 +18,7 @@ export const Chart5: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineMulti6.stories.ts
+++ b/src/stories/autogen/lineMulti6.stories.ts
@@ -18,6 +18,7 @@ export const Chart6: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineMulti7.stories.ts
+++ b/src/stories/autogen/lineMulti7.stories.ts
@@ -18,6 +18,7 @@ export const Chart7: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineMulti8.stories.ts
+++ b/src/stories/autogen/lineMulti8.stories.ts
@@ -18,6 +18,7 @@ export const Chart8: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineMulti9.stories.ts
+++ b/src/stories/autogen/lineMulti9.stories.ts
@@ -18,6 +18,7 @@ export const Chart9: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle12.stories.ts
+++ b/src/stories/autogen/lineSingle12.stories.ts
@@ -18,6 +18,7 @@ export const Chart12: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle13.stories.ts
+++ b/src/stories/autogen/lineSingle13.stories.ts
@@ -18,6 +18,7 @@ export const Chart13: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle14.stories.ts
+++ b/src/stories/autogen/lineSingle14.stories.ts
@@ -18,6 +18,7 @@ export const Chart14: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle15.stories.ts
+++ b/src/stories/autogen/lineSingle15.stories.ts
@@ -18,6 +18,7 @@ export const Chart15: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle16.stories.ts
+++ b/src/stories/autogen/lineSingle16.stories.ts
@@ -18,6 +18,7 @@ export const Chart16: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle17.stories.ts
+++ b/src/stories/autogen/lineSingle17.stories.ts
@@ -18,6 +18,7 @@ export const Chart17: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle18.stories.ts
+++ b/src/stories/autogen/lineSingle18.stories.ts
@@ -18,6 +18,7 @@ export const Chart18: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle19.stories.ts
+++ b/src/stories/autogen/lineSingle19.stories.ts
@@ -18,6 +18,7 @@ export const Chart19: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle20.stories.ts
+++ b/src/stories/autogen/lineSingle20.stories.ts
@@ -18,6 +18,7 @@ export const Chart20: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle21.stories.ts
+++ b/src/stories/autogen/lineSingle21.stories.ts
@@ -18,6 +18,7 @@ export const Chart21: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle22.stories.ts
+++ b/src/stories/autogen/lineSingle22.stories.ts
@@ -18,6 +18,7 @@ export const Chart22: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle23.stories.ts
+++ b/src/stories/autogen/lineSingle23.stories.ts
@@ -18,6 +18,7 @@ export const Chart23: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle24.stories.ts
+++ b/src/stories/autogen/lineSingle24.stories.ts
@@ -18,6 +18,7 @@ export const Chart24: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle25.stories.ts
+++ b/src/stories/autogen/lineSingle25.stories.ts
@@ -18,6 +18,7 @@ export const Chart25: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle26.stories.ts
+++ b/src/stories/autogen/lineSingle26.stories.ts
@@ -18,6 +18,7 @@ export const Chart26: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle27.stories.ts
+++ b/src/stories/autogen/lineSingle27.stories.ts
@@ -18,6 +18,7 @@ export const Chart27: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle28.stories.ts
+++ b/src/stories/autogen/lineSingle28.stories.ts
@@ -18,6 +18,7 @@ export const Chart28: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle29.stories.ts
+++ b/src/stories/autogen/lineSingle29.stories.ts
@@ -18,6 +18,7 @@ export const Chart29: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle30.stories.ts
+++ b/src/stories/autogen/lineSingle30.stories.ts
@@ -18,6 +18,7 @@ export const Chart30: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle31.stories.ts
+++ b/src/stories/autogen/lineSingle31.stories.ts
@@ -18,6 +18,7 @@ export const Chart31: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle32.stories.ts
+++ b/src/stories/autogen/lineSingle32.stories.ts
@@ -18,6 +18,7 @@ export const Chart32: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle33.stories.ts
+++ b/src/stories/autogen/lineSingle33.stories.ts
@@ -18,6 +18,7 @@ export const Chart33: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle34.stories.ts
+++ b/src/stories/autogen/lineSingle34.stories.ts
@@ -18,6 +18,7 @@ export const Chart34: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lineSingle35.stories.ts
+++ b/src/stories/autogen/lineSingle35.stories.ts
@@ -18,6 +18,7 @@ export const Chart35: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "line",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lollipopMulti0.stories.ts
+++ b/src/stories/autogen/lollipopMulti0.stories.ts
@@ -18,6 +18,7 @@ export const Chart0: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "lollipop",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/lollipopSingle1.stories.ts
+++ b/src/stories/autogen/lollipopSingle1.stories.ts
@@ -18,6 +18,7 @@ export const Chart1: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "lollipop",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/pie40.stories.ts
+++ b/src/stories/autogen/pie40.stories.ts
@@ -18,6 +18,7 @@ export const Chart40: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "pie",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/scatter42.stories.ts
+++ b/src/stories/autogen/scatter42.stories.ts
@@ -18,6 +18,7 @@ export const Chart42: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "scatter",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/scatter44.stories.ts
+++ b/src/stories/autogen/scatter44.stories.ts
@@ -18,6 +18,7 @@ export const Chart44: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "scatter",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/scatter47.stories.ts
+++ b/src/stories/autogen/scatter47.stories.ts
@@ -18,6 +18,7 @@ export const Chart47: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "scatter",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/scatter49.stories.ts
+++ b/src/stories/autogen/scatter49.stories.ts
@@ -18,6 +18,7 @@ export const Chart49: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "scatter",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/scatter51.stories.ts
+++ b/src/stories/autogen/scatter51.stories.ts
@@ -18,6 +18,7 @@ export const Chart51: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "scatter",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineMulti10.stories.ts
+++ b/src/stories/autogen/steplineMulti10.stories.ts
@@ -18,6 +18,7 @@ export const Chart10: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineMulti11.stories.ts
+++ b/src/stories/autogen/steplineMulti11.stories.ts
@@ -18,6 +18,7 @@ export const Chart11: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineMulti2.stories.ts
+++ b/src/stories/autogen/steplineMulti2.stories.ts
@@ -18,6 +18,7 @@ export const Chart2: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineMulti3.stories.ts
+++ b/src/stories/autogen/steplineMulti3.stories.ts
@@ -18,6 +18,7 @@ export const Chart3: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineMulti4.stories.ts
+++ b/src/stories/autogen/steplineMulti4.stories.ts
@@ -18,6 +18,7 @@ export const Chart4: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineMulti5.stories.ts
+++ b/src/stories/autogen/steplineMulti5.stories.ts
@@ -18,6 +18,7 @@ export const Chart5: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineMulti6.stories.ts
+++ b/src/stories/autogen/steplineMulti6.stories.ts
@@ -18,6 +18,7 @@ export const Chart6: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineMulti7.stories.ts
+++ b/src/stories/autogen/steplineMulti7.stories.ts
@@ -18,6 +18,7 @@ export const Chart7: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineMulti8.stories.ts
+++ b/src/stories/autogen/steplineMulti8.stories.ts
@@ -18,6 +18,7 @@ export const Chart8: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineMulti9.stories.ts
+++ b/src/stories/autogen/steplineMulti9.stories.ts
@@ -18,6 +18,7 @@ export const Chart9: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle12.stories.ts
+++ b/src/stories/autogen/steplineSingle12.stories.ts
@@ -18,6 +18,7 @@ export const Chart12: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle13.stories.ts
+++ b/src/stories/autogen/steplineSingle13.stories.ts
@@ -18,6 +18,7 @@ export const Chart13: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle14.stories.ts
+++ b/src/stories/autogen/steplineSingle14.stories.ts
@@ -18,6 +18,7 @@ export const Chart14: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle15.stories.ts
+++ b/src/stories/autogen/steplineSingle15.stories.ts
@@ -18,6 +18,7 @@ export const Chart15: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle16.stories.ts
+++ b/src/stories/autogen/steplineSingle16.stories.ts
@@ -18,6 +18,7 @@ export const Chart16: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle17.stories.ts
+++ b/src/stories/autogen/steplineSingle17.stories.ts
@@ -18,6 +18,7 @@ export const Chart17: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle18.stories.ts
+++ b/src/stories/autogen/steplineSingle18.stories.ts
@@ -18,6 +18,7 @@ export const Chart18: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle19.stories.ts
+++ b/src/stories/autogen/steplineSingle19.stories.ts
@@ -18,6 +18,7 @@ export const Chart19: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle20.stories.ts
+++ b/src/stories/autogen/steplineSingle20.stories.ts
@@ -18,6 +18,7 @@ export const Chart20: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle21.stories.ts
+++ b/src/stories/autogen/steplineSingle21.stories.ts
@@ -18,6 +18,7 @@ export const Chart21: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle22.stories.ts
+++ b/src/stories/autogen/steplineSingle22.stories.ts
@@ -18,6 +18,7 @@ export const Chart22: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle23.stories.ts
+++ b/src/stories/autogen/steplineSingle23.stories.ts
@@ -18,6 +18,7 @@ export const Chart23: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle24.stories.ts
+++ b/src/stories/autogen/steplineSingle24.stories.ts
@@ -18,6 +18,7 @@ export const Chart24: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle25.stories.ts
+++ b/src/stories/autogen/steplineSingle25.stories.ts
@@ -18,6 +18,7 @@ export const Chart25: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle26.stories.ts
+++ b/src/stories/autogen/steplineSingle26.stories.ts
@@ -18,6 +18,7 @@ export const Chart26: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle27.stories.ts
+++ b/src/stories/autogen/steplineSingle27.stories.ts
@@ -18,6 +18,7 @@ export const Chart27: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle28.stories.ts
+++ b/src/stories/autogen/steplineSingle28.stories.ts
@@ -18,6 +18,7 @@ export const Chart28: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle29.stories.ts
+++ b/src/stories/autogen/steplineSingle29.stories.ts
@@ -18,6 +18,7 @@ export const Chart29: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle30.stories.ts
+++ b/src/stories/autogen/steplineSingle30.stories.ts
@@ -18,6 +18,7 @@ export const Chart30: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle31.stories.ts
+++ b/src/stories/autogen/steplineSingle31.stories.ts
@@ -18,6 +18,7 @@ export const Chart31: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle32.stories.ts
+++ b/src/stories/autogen/steplineSingle32.stories.ts
@@ -18,6 +18,7 @@ export const Chart32: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle33.stories.ts
+++ b/src/stories/autogen/steplineSingle33.stories.ts
@@ -18,6 +18,7 @@ export const Chart33: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle34.stories.ts
+++ b/src/stories/autogen/steplineSingle34.stories.ts
@@ -18,6 +18,7 @@ export const Chart34: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/autogen/steplineSingle35.stories.ts
+++ b/src/stories/autogen/steplineSingle35.stories.ts
@@ -18,6 +18,7 @@ export const Chart35: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "stepline",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {

--- a/src/stories/chartSelectorHelper.ts
+++ b/src/stories/chartSelectorHelper.ts
@@ -10,12 +10,12 @@ import { type CatalogListing } from '@fizz/chart-data';
 const CHART_TYPE_FAMILIES = ['line', 'bar', 'pastry', 'scatter'] as const;
 export type ChartFamily = typeof CHART_TYPE_FAMILIES[number];
 
-export type ChartType = 'line' | 'stepline' | 'bar' | 'column' | 'lollipop' | 'pie' | 'scatter';
+export type ChartType = 'line' | 'stepline' | 'bar' | 'column' | 'lollipop' | 'pie' | 'scatter' | 'donut';
 
 export const FAMILY_MEMBERS: Record<ChartFamily, ChartType[]> = {
   'line': ['line', 'stepline'],
   'bar': ['bar', 'column', 'lollipop'],
-  'pastry': ['pie'],
+  'pastry': ['pie', 'donut'],
   'scatter': ['scatter']
 }
 

--- a/src/stories/chartSelectorHelper.ts
+++ b/src/stories/chartSelectorHelper.ts
@@ -2,6 +2,7 @@
 
 // Imports
 
+import { ChartType } from '@fizz/paramanifest';
 import CHART_CATALOG from '../../node_modules/@fizz/chart-data/data/chart_catalog.json' with { type: "json" };
 import { type CatalogListing } from '@fizz/chart-data';
 
@@ -9,8 +10,6 @@ import { type CatalogListing } from '@fizz/chart-data';
 
 const CHART_TYPE_FAMILIES = ['line', 'bar', 'pastry', 'scatter'] as const;
 export type ChartFamily = typeof CHART_TYPE_FAMILIES[number];
-
-export type ChartType = 'line' | 'stepline' | 'bar' | 'column' | 'lollipop' | 'pie' | 'scatter' | 'donut';
 
 export const FAMILY_MEMBERS: Record<ChartFamily, ChartType[]> = {
   'line': ['line', 'stepline'],

--- a/src/stories/chartSelectorHelper.ts
+++ b/src/stories/chartSelectorHelper.ts
@@ -2,7 +2,7 @@
 
 // Imports
 
-import { ChartType } from '@fizz/paramanifest';
+import { type ChartType } from '@fizz/paramanifest';
 import CHART_CATALOG from '../../node_modules/@fizz/chart-data/data/chart_catalog.json' with { type: "json" };
 import { type CatalogListing } from '@fizz/chart-data';
 

--- a/src/stories/storiesBuilder.ts
+++ b/src/stories/storiesBuilder.ts
@@ -8,9 +8,10 @@ import fs from 'node:fs';
 import { type CatalogListing } from '@fizz/chart-data';
 
 import { template } from './storyTemplate.ts';
-import { type ChartFamily, type ChartType, FAMILY_MEMBERS, familyCatalogMap, familyCatalogMapMulti} 
+import { type ChartFamily, FAMILY_MEMBERS, familyCatalogMap, familyCatalogMapMulti} 
   from './chartSelectorHelper.ts';
 import { allTemplate } from './allStoriesTemplate.ts';
+import { type ChartType } from '@fizz/paramanifest';
 //import { capitalize } from '../../lib/common/utils.ts';
 
 function capitalize(string: string) {

--- a/src/stories/storiesBuilder.ts
+++ b/src/stories/storiesBuilder.ts
@@ -28,7 +28,7 @@ function generateStory(
   index: number
 ): void {
   const chartFolder = capitalize(chartType) + ' Charts';
-  const code = printf(template, { manifestTitle, chartFolder, manifestPath, index });
+  const code = printf(template, { manifestTitle, chartFolder, manifestPath, index, chartType });
   fs.writeFileSync(`${AUTOGEN_PATH}${chartType}${index}.stories.ts`, code, 'utf8');
 }
 
@@ -41,7 +41,7 @@ function generateStoryMulti(
 ): void {
   const multiText = multi ? 'Multi' : 'Single';
   const chartFolder = `${capitalize(chartType)} ${multiText} Charts`;
-  const code = printf(template, { manifestTitle, chartFolder, manifestPath, index });
+  const code = printf(template, { manifestTitle, chartFolder, manifestPath, index, chartType });
   fs.writeFileSync(`${AUTOGEN_PATH}${chartType}${multiText}${index}.stories.ts`, code, 'utf8');
 }
 
@@ -90,7 +90,7 @@ function generateAllStory(
 ): void {
   const chartFolder = capitalize(chartType) + ' Charts';
   const storyName = `All${capitalize(chartType)}Charts`;
-  const code = printf(allTemplate, { chartFolder, storyName, family, multi: 'false' });
+  const code = printf(allTemplate, { chartFolder, storyName, family, multi: 'false', chartType });
   fs.writeFileSync(`${AUTOGEN_PATH}all${chartType}.stories.ts`, code, 'utf8');
 }
 
@@ -102,7 +102,7 @@ function generateAllStoryMulti(
   const multiText = multi ? 'multi' : 'single';
   const chartFolder = `${capitalize(chartType)} ${capitalize(multiText)} Charts`;
   const storyName = `All${capitalize(multiText)}${capitalize(chartType)}Charts`;
-  const code = printf(allTemplate, { chartType, chartFolder, storyName, family, multi: 'true' });
+  const code = printf(allTemplate, { chartFolder, storyName, family, multi: 'true', chartType });
   fs.writeFileSync(`${AUTOGEN_PATH}all${multiText}${chartType}.stories.ts`, code, 'utf8');
 }
 

--- a/src/stories/storyTemplate.ts
+++ b/src/stories/storyTemplate.ts
@@ -18,6 +18,7 @@ export const Chart%(index)s: Story = {
     config: { // change to configFile: "./sample_config.json",
       "ui.colorVisionMode": "deutan"
     },
+    forcecharttype: "%(chartType)s",
     /*keybindings: { // change to keybindingsFile: './sample_keybindings.json',
       "chart": {
         "a": {


### PR DESCRIPTION
Adds donut chart stories.

This required adding an option to force a ParaChart to have a different chart type than its manifest specifies. This is done via the `forcecharttype` attribute