### PR TITLE
Re-enables clustering

### DIFF
--- a/lib/view/data/datapoint.ts
+++ b/lib/view/data/datapoint.ts
@@ -5,8 +5,6 @@ import { type DataCursor } from '../../store';
 import { type Shape } from '../shape/shape';
 import { Rect } from '../shape/rect';
 
-import { type clusterObject } from '@fizz/clustering';
-
 import { type ClassInfo, classMap } from 'lit/directives/class-map.js';
 import { type StyleInfo, styleMap } from 'lit/directives/style-map.js';
 import { svg, nothing, TemplateResult } from 'lit';
@@ -187,18 +185,6 @@ export class DatapointView extends DataView {
   protected _createSymbol() {
     const series = this.seriesProps;
     let symbolType = series.symbol;
-    const index = this.parent.children.indexOf(this);
-    let color: number = series.color;
-    const types = new DataSymbols().types;
-    if (this.chart.isClustering){ 
-      let clustering = this.chart.clustering as clusterObject[]
-      for (let clusterId in clustering){
-        if (clustering[clusterId].dataPointIDs.indexOf(index) > -1){
-          color = Number(clusterId)
-          symbolType = types[color % types.length]
-        }
-      }
-    }
     this._symbol = DataSymbol.fromType(this.paraview, symbolType);
     this._symbol.id = `${this._id}-sym`;
     this.append(this._symbol);
@@ -219,7 +205,7 @@ export class DatapointView extends DataView {
 
   protected get _symbolColor() {
     return this.paraview.store.isVisited(this.seriesKey, this.index)
-      ? -1
+      ? -1 as number
       : undefined;
   }
 

--- a/lib/view/datalayer.ts
+++ b/lib/view/datalayer.ts
@@ -32,7 +32,6 @@ import { type HotkeyEvent } from '../store/keymap_manager';
 import { ChartLandingView, DatapointView, SeriesView, type DataView } from './data';
 import { type LegendItem } from './legend';
 
-import { type clusterObject } from '@fizz/clustering';
 import { queryMessages } from '../store/query_utils';
 import { interpolate } from '@fizz/templum';
 
@@ -74,9 +73,6 @@ export abstract class DataLayer extends ChartLayer {
   // Series of previously-visited datapoint.
   //private _prevDatapointSeries?: string;
   //private _currentRecord = 0;
-
-  protected _isClustering: boolean = false;
-  protected _clustering?: clusterObject[];
 
   constructor(paraview: ParaView, public readonly dataLayerIndex: number) {
     super(paraview);
@@ -195,13 +191,6 @@ export abstract class DataLayer extends ChartLayer {
 
   get datapointViews() {
     return this._chartLandingView.datapointViews;
-  }
-
-  get isClustering(){
-    return this._isClustering;
-  }
-  get clustering(){
-    return this._clustering;
   }
 
   get visitedDatapointViews() {

--- a/lib/view/pointchart.ts
+++ b/lib/view/pointchart.ts
@@ -20,7 +20,6 @@ import { AxisInfo } from '../common/axisinfo';
 import { type PointChartType } from '../store/settings_types';
 import { enumerate, strToId } from '@fizz/paramodel';
 
-import { type coord, generateClusterAnalysis } from '@fizz/clustering';
 import { formatBox } from '@fizz/parasummary';
 
 /**
@@ -81,16 +80,6 @@ export abstract class PointChart extends XYChart {
   //      datapointView.computeLayout();
   //   }
   // }
-
-  protected _generateClustering(){
-    const data: Array<coord> = []
-    const yValues = this.paraview.store.model!.allFacetValues('y')!.map((y) => y.value as number);
-    const xValues = this.paraview.store.model!.allFacetValues('x')!.map((y) => y.value as number);
-    for (let i = 0; i < xValues.length; i++){
-      data.push({x: xValues[i], y: yValues[i]});
-    } 
-    this._clustering = generateClusterAnalysis(data, true);
-  } 
 
   seriesRef(series: string) {
     return this.paraview.ref<SVGGElement>(`series.${series}`);

--- a/lib/view/scatter.ts
+++ b/lib/view/scatter.ts
@@ -4,16 +4,35 @@ import { type ScatterSettings, Setting, type DeepReadonly } from '../store/setti
 import { type XYSeriesView } from './xychart';
 import { ParaView } from '../paraview';
 import { AxisInfo } from '../common/axisinfo';
+import { clusterObject, coord, generateClusterAnalysis } from '@fizz/clustering';
+import { DataSymbol, DataSymbols } from './symbol';
+import { TemplateResult } from 'lit';
 
 export class ScatterPlot extends PointChart {
-  
+
+  protected _isClustering: boolean = false;
+  protected _clustering?: clusterObject[];
+
   constructor(paraview: ParaView, index: number) {
     super(paraview, index);
-    this._isClustering = true;
+    if (this.paraview.store.model?.numSeries === 1){
+      this._isClustering = true;
+    }
+    else{
+      this._isClustering = false;
+    }
   }
 
   get settings() {
     return super.settings as DeepReadonly<ScatterSettings>;
+  }
+
+  get isClustering(){
+    return this._isClustering;
+  }
+
+  get clustering(){
+    return this._clustering;
   }
 
   settingDidChange(key: string, value: Setting | undefined) {
@@ -32,9 +51,30 @@ export class ScatterPlot extends PointChart {
     return new ScatterPoint(seriesView);
   }
 
+  protected _createDatapoints(): void {
+    
+    super._createDatapoints()
+    if (this.isClustering){
+      this._generateClustering();
+    }
+  }
+
+  protected _generateClustering(){
+    const data: Array<coord> = []
+    const seriesList = this.paraview.store.model!.series
+    for (let series of seriesList){
+      for (let i = 0; i < series.length; i++){
+        data.push({x: Number(series.rawData[i].x), y: Number(series.rawData[i].y)});
+      } 
+    }
+    this._clustering = generateClusterAnalysis(data, true);
+  } 
+  
 }
 
 class ScatterPoint extends ChartPoint {
+  declare readonly chart: ScatterPlot;
+  protected symbolColor: number | undefined;
   protected _computeX() {
     // Scales points in proportion to the data range
     const xTemp = (this.datapoint.x.value as number - this.chart.axisInfo!.xLabelInfo.min!) / this.chart.axisInfo!.xLabelInfo.range!;
@@ -42,7 +82,48 @@ class ScatterPoint extends ChartPoint {
     return parentWidth * xTemp;
   }
 
-  protected _createShape() {
+  get width() {
+    if (this._symbol?.width!){
+      return 2 * 1.5 * this._symbol!.width
+    }
+    else{
+      return 36
+    }
+  }
+
+  protected _createShape(): void {
+  }
+
+  protected get _symbolColor() {
+    return this.paraview.store.isVisited(this.seriesKey, this.index)
+      ? -1
+      : this.symbolColor;
+  }
+
+  protected _createSymbol(): void {
+    const series = this.seriesProps;
+    let symbolType = series.symbol;
+    const index = this.parent.children.indexOf(this);
+    let color: number = series.color;
+    const types = new DataSymbols().types;
+    if (this.chart.isClustering) {
+      let clustering = this.chart.clustering as clusterObject[]
+      for (let clusterId in clustering) {
+        if (clustering[clusterId].dataPointIDs.indexOf(index) > -1) {
+          color = Number(clusterId)
+          symbolType = types[color % types.length]
+        }
+      }
+    }
+
+    this._symbol = DataSymbol.fromType(this.paraview, symbolType, {
+      strokeWidth: this.paraview.store.settings.chart.symbolStrokeWidth,
+      color: color,
+      lighten: true
+    });
+    this._symbol.id = `${this._id}-sym`;
+    this.symbolColor = color;
+    this.append(this._symbol);
   }
 }
 


### PR DESCRIPTION
For real this time hopefully
-Moves everything clustering related from `datalayer.ts`, `pointchart.ts`, and `datapoint.ts` into `scatter.ts`.
-Only enables clustering for scatterplots with a single series, to prevent the clustering breaking with datasets like the Iris dataset.
-Adds a `width` getter to `ScatterPoint` in order to fix the selection markers being abnormally small on scatterplots. Not rigorously tested and I'm not totally sure why I need to multiple the width by 2, but it looks much better than current.
-Adds a `symbolColor` property to `Scatterpoint`, used to store the symbol color because it otherwise gets overwritten by `DatapointView.content()`
-Also changes the return value type of `DatapointView._symbolColor` from a number literal to a generic number type because I need it to return numbers other than just -1.