### PR TITLE
Re-adds protan palette highlight

### DIFF
--- a/lib/common/colors.ts
+++ b/lib/common/colors.ts
@@ -431,6 +431,10 @@ export class Colors {
           {
             value: 'hsl(324, 35%, 62%)',
             name: ''
+          },
+          {
+            value: 'hsl(0, 100%, 50%)',
+            name: 'highlight'
           }
         ]
       },


### PR DESCRIPTION
At some point during the refactor, the protan palette lost it's "highlight" color, throwing an error if the palette was used while a point or series was highlighted. This adds it back.