### PR TITLE
Adds sparkbraille

### DIFF
--- a/lib/control_panel/control_panel.ts
+++ b/lib/control_panel/control_panel.ts
@@ -275,7 +275,6 @@ export class ParaControlPanel extends logging(ParaComponent) {
             .controlPanel=${this}
           ></para-description-panel>
         </fizz-tab-panel>
-        <!--
         <fizz-tab-panel
           tablabel="Data"
           icon=${tabDataIcon}
@@ -288,7 +287,6 @@ export class ParaControlPanel extends logging(ParaComponent) {
             .isSparkBrailleVisible=${this.settings.isSparkBrailleVisible}
           ></para-data-panel>
         </fizz-tab-panel>
-      -->
         <fizz-tab-panel
           tablabel="Colors"
           icon=${tabColorsIcon}

--- a/lib/control_panel/tab_panels/data.ts
+++ b/lib/control_panel/tab_panels/data.ts
@@ -17,10 +17,12 @@ import { ref, createRef } from 'lit/directives/ref.js';
 export class DataPanel extends ControlPanelTabPanel {
 
   @property() sparkBrailleData!: string;
-  @property({type: Boolean}) isSparkBrailleVisible = true;
+  @property({type: Boolean}) isSparkBrailleVisible = false;
 
   protected _sparkBrailleRef = createRef<sb.SparkBraille>();
   protected _sparkBrailleWrapperRef = createRef<HTMLDivElement>();
+  protected _isSBProp = false;
+  protected _isBar = false;
 
   protected _saveChart() {
     const paraView = this.controlPanel.parentElement!.firstElementChild as ParaView;
@@ -120,6 +122,10 @@ export class DataPanel extends ControlPanelTabPanel {
   ];
 
   render() {
+    const paraView = this.controlPanel.parentElement!.firstElementChild as ParaView;
+    this.sparkBrailleData = paraView.store._sparkBrailleData
+    this._isSBProp = paraView.store.settings.controlPanel.isSparkBrailleProportional;
+    this._isBar = paraView.store.settings.controlPanel.isSparkBrailleBar;
     return html`   
       <div 
         id="data-page" 
@@ -129,14 +135,15 @@ export class DataPanel extends ControlPanelTabPanel {
           <p>Source: <span id="source-name">unknown</span></p>
         </div>
         <div id="data-buttons">
-          <!--
           ${this.controlPanel.settings.isSparkBrailleControlVisible
             ? html`  
               <button 
                 @click=${() => {
                   this.isSparkBrailleVisible = !this.isSparkBrailleVisible;
                   // XXX Does this work?
-                  this._store.settings.controlPanel.isSparkBrailleVisible = this.isSparkBrailleVisible;
+                  paraView.store.updateSettings(draft => {
+                    draft.controlPanel.isSparkBrailleVisible = this.isSparkBrailleVisible;
+                  })
                   //this.controlPanel.requestUpdate();
                   this._sparkBrailleRef.value!.focus();
                 }}
@@ -146,7 +153,6 @@ export class DataPanel extends ControlPanelTabPanel {
             `
             : nothing
           }
-          -->
           <!--<button 
             @click=${() => {
                 // this.controlPanel.dialog.show(
@@ -196,21 +202,23 @@ export class DataPanel extends ControlPanelTabPanel {
         ${ref(this._sparkBrailleWrapperRef)} 
         id="sparkbraille"
         class=${this.isSparkBrailleVisible ? nothing : 'hidden'}
-      >
+        ?hidden=${!this.isSparkBrailleVisible}
+    >
         <!-- 
           What should happen when a braille cell is selected?
         -->
-        <!--
         <fizz-sparkbraille
           ${ref(this._sparkBrailleRef)}
-          data=${this.sparkBrailleData}
+          ?bar=${this._isBar}
+          ?isProp=${this._isSBProp}
+          data=${this._isSBProp ? '' : this.sparkBrailleData}
+          labeledData=${this._isSBProp ? this.sparkBrailleData : ''}
           @select=${(e: CustomEvent) => {
             const index = e.detail*2;
             //chart.hiliteSegmentRangeById('series', `${index}`, `${index + 1}`);
           }}
         >
         </fizz-sparkbraille>
--->
       </div>
     `;
   }

--- a/lib/store/parastore.ts
+++ b/lib/store/parastore.ts
@@ -55,6 +55,7 @@ export class ParaStore extends State {
   @property() settings: Settings;
   @property() darkMode = false;
   @property() announcement: Announcement = { text: '' };
+  @property()  _sparkBrailleData: string = ''
 
   @property() protected data: AllSeriesData | null = null;
   @property() protected focused = 'chart';

--- a/lib/store/settings_defaults.ts
+++ b/lib/store/settings_defaults.ts
@@ -306,6 +306,8 @@ export const defaults: Settings = {
     isCaptionVisible: true,
     isStatusBarVisible: true,
     isSparkBrailleVisible: false,
+    isSparkBrailleProportional: false,
+    isSparkBrailleBar: false,
     isSparkBrailleControlVisible: true,
     isDataTabVisible: true,
     isColorsTabVisible: true,

--- a/lib/store/settings_types.ts
+++ b/lib/store/settings_types.ts
@@ -66,6 +66,8 @@ export interface ControlPanelSettings extends SettingGroup {
   isCaptionVisible: boolean;
   isStatusBarVisible: boolean;
   isSparkBrailleVisible: boolean;
+  isSparkBrailleProportional: boolean;
+  isSparkBrailleBar: boolean;
   isDataTabVisible: boolean;
   isColorsTabVisible: boolean;
   isAudioTabVisible: boolean;

--- a/lib/view/chart_type/pie.ts
+++ b/lib/view/chart_type/pie.ts
@@ -95,4 +95,15 @@ export class PieSlice extends RadialSlice {
     });
   }
 
+  onFocus() {
+    super.onFocus()
+    let data = []
+    for (let point of this.series.rawData) {
+      data.push({ label: point.x, value: Number(point.y) })
+    }
+    this.paraview.store.updateSettings(draft => {
+      draft.controlPanel.isSparkBrailleProportional = true
+    });
+    this.paraview.store._sparkBrailleData = JSON.stringify(data)
+  }
 }

--- a/lib/view/xychart.ts
+++ b/lib/view/xychart.ts
@@ -529,6 +529,15 @@ export class XYSeriesView extends SeriesView {
 
   onFocus() {
     super.onFocus();
+    let data = []
+    for (let point of this.series.rawData) {
+      data.push(point.y)
+    }
+    if (this.paraview.store.type == "bar" || this.paraview.store.type == "column"){
+      this.paraview.store.updateSettings(draft => {
+      draft.controlPanel.isSparkBrailleBar = true
+    })};
+    this.paraview.store._sparkBrailleData = data.join(' ');
     /*todo().deets!.sparkBrailleData = this.series.data.join(' ');
     this.eventActionManager!.dispatch('series_focused', {
       visited,
@@ -666,6 +675,15 @@ export abstract class XYDatapointView extends DatapointView {
 
   onFocus(isNewComponentFocus = false) {
     super.onFocus(isNewComponentFocus);
+    let data = []
+    for (let point of this.series.rawData){
+      data.push(point.y)
+    }
+    if (this.paraview.store.type == "bar" || this.paraview.store.type == "column"){
+      this.paraview.store.updateSettings(draft => {
+      draft.controlPanel.isSparkBrailleBar = true
+    })};
+    this.paraview.store._sparkBrailleData = data.join(' ');
     /*todo().deets!.sparkBrailleData = this.series.data.join(' ');
     if (todo().controller.settingStore.settings.sonification.isSoniEnabled) {
       this.chart.sonifier.playDatapoints(...visited.map(v => v.datapoint));

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@fizz/paramanifest": "^0.3.2",
         "@fizz/paramodel": "^0.1.7-alpha.0",
         "@fizz/parasummary": "^0.2.2-alpha.7",
+        "@fizz/sparkbraille-component": "^0.5.0",
         "@fizz/templum": "^0.4.2",
         "@fizz/todocharts": "^0.129.6",
         "@fizz/ui-components": "^0.69.3",
@@ -2111,9 +2112,9 @@
       }
     },
     "node_modules/@fizz/sparkbraille-component": {
-      "version": "0.2.0",
-      "resolved": "https://npm.fizz.studio/@fizz/sparkbraille-component/-/sparkbraille-component-0.2.0.tgz",
-      "integrity": "sha512-IGa64+jjdfShjHY6xy/HwrgERi9Z7hHjhNl+mC9SsTrTDMLFh+LuNW10kaqYb46XIgzD+Zo9BfhjYim/TBsWWg==",
+      "version": "0.5.0",
+      "resolved": "https://npm.fizz.studio/@fizz/sparkbraille-component/-/sparkbraille-component-0.5.0.tgz",
+      "integrity": "sha512-Tz3WzSYokD17+MznxdA3YkLpku7Q5oubFztxdy+h8FKC0bmSCz7CbC4iAEE7Y2AN2kWSOhhB6Qxhb0RfT3zlDg==",
       "license": "UNLICENSED",
       "dependencies": {
         "lit": "^3.2.1"
@@ -2222,6 +2223,15 @@
         "json-schema-to-typescript": "^13.1.2",
         "jsonpath": "^1.1.1",
         "vitest": "^2.1.2"
+      }
+    },
+    "node_modules/@fizz/todocharts/node_modules/@fizz/sparkbraille-component": {
+      "version": "0.2.0",
+      "resolved": "https://npm.fizz.studio/@fizz/sparkbraille-component/-/sparkbraille-component-0.2.0.tgz",
+      "integrity": "sha512-IGa64+jjdfShjHY6xy/HwrgERi9Z7hHjhNl+mC9SsTrTDMLFh+LuNW10kaqYb46XIgzD+Zo9BfhjYim/TBsWWg==",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "lit": "^3.2.1"
       }
     },
     "node_modules/@fizz/ui-components": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@fizz/paramanifest": "^0.3.2",
     "@fizz/paramodel": "^0.1.7-alpha.0",
     "@fizz/parasummary": "^0.2.2-alpha.7",
+    "@fizz/sparkbraille-component": "^0.5.0",
     "@fizz/templum": "^0.4.2",
     "@fizz/todocharts": "^0.129.6",
     "@fizz/ui-components": "^0.69.3",


### PR DESCRIPTION
Note: The sparkbraille displays don't show up on the non-FFB pie/donut charts because of errors thrown during the summary process. If you comment out these lines, the control panel shows and the display works. I'm making the PR with them not commented out as to not conflict with other branches.

-Updates the `sparkbraille-component` to work with bar charts and radial/proportional charts.
-Changes onFocus methods of `XYSeriesView`, `XYDatapointView`, and `PieSlice` to pass data and settings into the store. 
-Removes comment tags for the data panel and sparkbraille control button
-Adds `_sparkBrailleData` string property to `ParaStore`
-Adds new settings `isSparkBrailleBar` and `isSparkBrailleProportional` to `ControlPanelSettings`.
-Adds properties `_isSBProp` and `_isBar` to `DataPanel` class, used to track at render how data should be passed to the sparkbraille component
-Fixes the broken `isSparkBrailleVisible` settings update in the button click action
-Fixes the broken hidden tag on the div wrapper around the component. I'm not sure if the class is used for something else so I left it.