### PR TITLE
Add minor changes for headless mode.

### DIFF
--- a/etc/paracharts.api.md
+++ b/etc/paracharts.api.md
@@ -49,6 +49,14 @@ import * as ui from '@fizz/ui-components';
 import { View as View_2 } from '../base_view';
 import { XYDatapoint } from '@fizz/paramodel';
 
+// @public (undocumented)
+export type FieldInfo = {
+    name: string;
+    type: Datatype_2;
+};
+
+export { Manifest }
+
 // Warning: (ae-forgotten-export) The symbol "ParaChart_base" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -134,8 +142,6 @@ export class ParaHelper {
     protected _api: ParaApi;
     // (undocumented)
     protected _createParaChart(): void;
-    // Warning: (ae-forgotten-export) The symbol "FieldInfo" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     loadData(url: string): Promise<FieldInfo[]>;
     // (undocumented)

--- a/lib/headless/parahelper.ts
+++ b/lib/headless/parahelper.ts
@@ -4,6 +4,10 @@ import '../parachart/parachart';
 import { ParaApi } from '../api/api';
 import { type SourceKind, type FieldInfo } from '../loader/paraloader';
 
+export { FieldInfo };
+
+export { type Manifest } from '@fizz/paramanifest';
+
 export class ParaHelper {
 
   protected _paraChart!: ParaChart;

--- a/lib/paraview/paraview.ts
+++ b/lib/paraview/paraview.ts
@@ -98,8 +98,6 @@ export class ParaView extends logging(ParaComponent) {
         --focusShadowColor: gray;
         --focusShadow: drop-shadow(0px 0px 4px var(--focusShadowColor));
         display: block;
-      }
-      * {
         font-family: "Trebuchet MS", Helvetica, sans-serif;
         font-size: var(--chart-view-font-size, 1rem);
       }
@@ -365,10 +363,11 @@ export class ParaView extends logging(ParaComponent) {
   //   this._defsRef.value!.appendChild(el);
   // }
 
-   serialize() {
+  serialize() {
     const svg = this.root!.cloneNode(true) as SVGSVGElement;
+    svg.id = 'para-' + window.crypto.randomUUID();
 
-    const styles = this._extractStyles();
+    const styles = this._extractStyles(svg.id);
     const styleEl = document.createElementNS(SVGNS, 'style');
     styleEl.textContent = styles;
     svg.prepend(styleEl);
@@ -396,14 +395,14 @@ export class ParaView extends logging(ParaComponent) {
       .join('\n');
   }
 
-  protected _extractStyles() {
+  protected _extractStyles(id: string) {
     const stylesheets = this.shadowRoot!.adoptedStyleSheets;
     const out: string[] = [];
     for (const stylesheet of stylesheets) {
       const rules = stylesheet.cssRules;
       for (let i = 0; i < rules.length; i++) {
         const rule = rules.item(i) as CSSRule;
-        out.push(rule.cssText.replace(/^:host/, 'svg'));
+        out.push(rule.cssText.replace(/^:host/, `#${id}`));
       }
     }
     return out.join('\n');
@@ -482,6 +481,7 @@ export class ParaView extends logging(ParaComponent) {
         ${ref(this._rootRef)}
         xmlns=${SVGNS}
         data-charttype=${this.type}
+        width=${fixed`${this._viewBox.width}px`}
         height=${fixed`${this._viewBox.height}px`}
         class=${classMap(this._rootClasses())}
         viewBox=${fixed`${this._viewBox.x} ${this._viewBox.y} ${this._viewBox.width} ${this._viewBox.height}`}

--- a/lib/view/document_view.ts
+++ b/lib/view/document_view.ts
@@ -136,8 +136,8 @@ export class DocumentView extends Container(View) {
       this._vertAxis.orthoAxis = this._horizAxis;
       this._horizAxis.orthoAxis = this._vertAxis;
       // XXX Change this method to set axis.titleText
-      this.xAxis!.setAxisLabelText(this._store.model!.getAxisFacet('horiz')!.label);
-      this.yAxis!.setAxisLabelText(this._store.model!.getAxisFacet('vert')!.label);
+      this._horizAxis.setAxisLabelText(this._store.model!.getAxisFacet('horiz')!.label);
+      this._vertAxis.setAxisLabelText(this._store.model!.getAxisFacet('vert')!.label);
       this._horizAxis.createComponents();
       this._vertAxis.createComponents();
       this._horizAxis.layoutComponents();


### PR DESCRIPTION
- Export `FieldInfo` and `Manifest`.
- Add UUID to exported SVG, and scope toplevel styles to it.
- Add `width` attr to SVG.
- Fix axis labels.