### PR TITLE
Fixes various bugs, adds percentage axes option

### DIFF
--- a/lib/store/settings_defaults.ts
+++ b/lib/store/settings_defaults.ts
@@ -230,7 +230,8 @@ export const defaults: Settings = {
       selectedPointMarkerSize: {
         width: 20,
         height: 20,
-      }
+      },
+      relativeAxes: "Counts"
     },
     heatmap: {
       pointLabelFormat: 'raw',

--- a/lib/store/settings_types.ts
+++ b/lib/store/settings_types.ts
@@ -326,6 +326,7 @@ export interface HistogramSettings extends PointSettings {
   bins: number;
   displayAxis: string;
   groupingAxis: string;
+  relativeAxes: "Counts" | "Percentage";
 }
 
 


### PR DESCRIPTION
-Adds new setting `relativeAxes` which is set to "Count" (default) or "Percentage" depending on whether you want the dependent axis to show the absolute count or the relative proportion of data that each bin contains. See #252 
-Simplifies `createDatapoints()` so that all series data are put into the same bins, this will be expanded eventually but it allows more accurate binning of multi-series datasets currently.
-Overrides `createId` to not throw a bug with the jimerator. This may need to be changed eventually but it works for now.
-Fixes bug with histogram fill color