### PR TITLE
Fix negative barplot display and add darkened zero axes

### DIFF
--- a/lib/common/colors.ts
+++ b/lib/common/colors.ts
@@ -677,6 +677,7 @@ export class Colors {
                 <line class="pattern" x1="0" y="0" x2="0" y2="10" stroke='hsl(225, 30%, 52%)' stroke-width="5" />
               </pattern>
               `,
+              contrastValue: "hsl(0, 0%, 0%)",
             name: 'diagonal_lines'
           },
           {
@@ -685,6 +686,7 @@ export class Colors {
                 <circle cx="5" cy="5" r="2" fill='hsl(12, 69%, 35%)' />
               </pattern>
               `,
+              contrastValue: "hsl(0, 0%, 0%)",
             name: 'dots'
           },
           {
@@ -693,6 +695,7 @@ export class Colors {
                 <path d="M 10 0 L 0 0 0 10" fill="none" stroke='hsl(75, 43%, 45%)' stroke-width="5"/>
               </pattern>
               `,
+              contrastValue: "hsl(0, 0%, 0%)",
             name: 'grid'
           },
           {
@@ -701,6 +704,7 @@ export class Colors {
                 <path d="M 0 0 L 10 10 M 10 0 L 0 10" stroke='hsl(40, 98%, 69%)' stroke-width="3"/>
               </pattern>
                `,
+               contrastValue: "hsl(0, 0%, 0%)",
             name: 'crosshatch'
           },
           {
@@ -709,6 +713,7 @@ export class Colors {
                 <path d="M 0 5 Q 5 0, 10 5 T 20 5" fill="none" stroke='hsl(215, 37%, 66%)' stroke-width="3"/>
               </pattern>
               `,
+              contrastValue: "hsl(0, 0%, 0%)",
             name: 'waves'
           },
           {
@@ -716,6 +721,7 @@ export class Colors {
               <pattern id="Pattern5" class="pattern" patternUnits="userSpaceOnUse" width="10" height="10" patternTransform="rotate(135)">
                 <line x1="0" y="0" x2="0" y2="10" stroke='hsl(63, 100%, 23%)' stroke-width="5" />
               </pattern>`,
+              contrastValue: "hsl(0, 0%, 0%)",
             name: 'diagonal_lines2'
           },
           {
@@ -723,6 +729,7 @@ export class Colors {
               <pattern id="Pattern6" class="pattern" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
               <circle cx="10" cy="10" r="10" fill='hsl(34, 57%, 46%)'" />
               </pattern>`,
+              contrastValue: "hsl(0, 0%, 0%)",
             name: ''
           },
           {
@@ -840,12 +847,14 @@ export class Colors {
   }
 
   contrastValueAt(index: number) {
-    const colors = this._colorMap
+    const colors = this.palette.isPattern 
+      ? this.palette.patterns!
+      : this._colorMap
       ? this._colorMap.map(i => this.palette.colors[i])
       : this.palette.colors;
     if (index === -1) {
       // highlight
-      return colors.at(-1)!.value;
+      return colors.at(-1)!.contrastValue;
     }
     // Never use 'highlight' for any series/datapoint color
     return colors[index % (colors.length - 1)].contrastValue ?? `hsl(0, 0%, 100%)`;

--- a/lib/paraview/paraview.ts
+++ b/lib/paraview/paraview.ts
@@ -211,12 +211,6 @@ export class ParaView extends logging(ParaComponent) {
         stroke-dasharray: 12 12;
         stroke-opacity: 0.8;
       }
-      .visible-axis{
-        stroke: black;
-        stroke-width: 4;
-        stroke-dasharray: 25 10;
-        stroke-opacity: 0.5;
-      }
     `
   ];
 

--- a/lib/paraview/paraview.ts
+++ b/lib/paraview/paraview.ts
@@ -133,6 +133,10 @@ export class ParaView extends logging(ParaComponent) {
         stroke: var(--axisLineColor);
         opacity: 0.2;
       }
+      #grid-zero {
+        opacity: 0.6;
+        stroke-width: 2;
+      }  
       .tick-horiz {
         stroke: black;
       }

--- a/lib/paraview/paraview.ts
+++ b/lib/paraview/paraview.ts
@@ -207,6 +207,12 @@ export class ParaView extends logging(ParaComponent) {
         stroke-dasharray: 12 12;
         stroke-opacity: 0.8;
       }
+      .visible-axis{
+        stroke: black;
+        stroke-width: 4;
+        stroke-dasharray: 25 10;
+        stroke-opacity: 0.5;
+      }
     `
   ];
 

--- a/lib/view/layers/data/chart_type/bar_chart.ts
+++ b/lib/view/layers/data/chart_type/bar_chart.ts
@@ -685,7 +685,7 @@ export class Bar extends XYDatapointView {
   get selectedMarker() {
     return new RectShape(this.paraview, {
       width: this._width + 4,
-      height: this._height + 4,
+      height: Math.abs(this._height) + 4,
       x: this._x - 2,
       y: this._y - 2,
       fill: 'none',

--- a/lib/view/layers/data/chart_type/bar_chart.ts
+++ b/lib/view/layers/data/chart_type/bar_chart.ts
@@ -16,8 +16,6 @@ import { formatBox } from '@fizz/parasummary';
 import { interpolate } from '@fizz/templum';
 
 import { StyleInfo } from 'lit/directives/style-map.js';
-import { PathShape } from '../../../shape/path';
-import { Vec2 } from '../../../../common/vector';
 
 type BarClusterMap = {[key: string]: BarCluster};
 

--- a/lib/view/layers/data/chart_type/bar_chart.ts
+++ b/lib/view/layers/data/chart_type/bar_chart.ts
@@ -354,21 +354,6 @@ export class BarChart extends XYChart {
 
   protected _completeLayout() {
     super._completeLayout();
-
-    const yValues = Object.values(this._clusteredData).flatMap(c =>
-      Object.values(c.stacks).map(s => Object.values(s.bars)
-        .map(item => item.value.value)
-        .reduce((a, b) => a + b, 0)))
-    if (Math.min(...yValues) < 0) {
-      const zeroHeight = (this.axisInfo!.yLabelInfo.max! * this.parent.logicalHeight / this.axisInfo!.yLabelInfo.range!);
-      const xAxis = new PathShape(this.paraview, {
-        x: this._x,
-        y: this._y,
-        points: [new Vec2(0, zeroHeight), new Vec2(this.parent.logicalWidth, zeroHeight),]
-      });
-      xAxis.classInfo = { 'visible-axis': true }
-      this.chartLandingView.append(xAxis)
-    }
     // if (this.paraview.store.settings.type.bar.isDrawStackLabels) {
     //   for (const [clusterKey, cluster] of Object.entries(this._bars)) {
     //     for (const [stackKey, stack] of Object.entries(cluster.stacks)) {

--- a/lib/view/layers/data/chart_type/bar_chart.ts
+++ b/lib/view/layers/data/chart_type/bar_chart.ts
@@ -600,7 +600,7 @@ export class Bar extends XYDatapointView {
     const zeroHeight = this.chart.parent.logicalHeight - (this.chart.axisInfo!.yLabelInfo.max! * this.chart.parent.logicalHeight / this.chart.axisInfo!.yLabelInfo.range!);
     this._width = this.chart.stackWidth;
     // @ts-ignore
-    this._height = (this.datapoint.data.y.value as number)*pxPerYUnit;
+    this._height = Math.abs((this.datapoint.data.y.value as number)*pxPerYUnit);
     //this._x = this._stack.x + this._stack.cluster.x; // - this.width/2; // + BarCluster.width/2 - this.width/2;
     this._x = this.chart.settings.clusterGap/2
       + this.chart.clusterWidth*this._stack.cluster.index
@@ -676,7 +676,7 @@ export class Bar extends XYDatapointView {
       x: this._x,
       y: this._y,
       width: this._width,
-      height: Math.abs(this._height),
+      height: this._height,
       isPattern: isPattern ? true : false
     });
     super._createShape();
@@ -685,7 +685,7 @@ export class Bar extends XYDatapointView {
   get selectedMarker() {
     return new RectShape(this.paraview, {
       width: this._width + 4,
-      height: Math.abs(this._height) + 4,
+      height: this._height + 4,
       x: this._x - 2,
       y: this._y - 2,
       fill: 'none',

--- a/lib/view/rule.ts
+++ b/lib/view/rule.ts
@@ -35,7 +35,8 @@ export abstract class AxisRule extends View {
     paraview: ParaView,
     protected _major = true,
     length: number,
-    protected _orientation: RuleOrientation
+    protected _orientation: RuleOrientation, 
+    private darken: boolean = false
   ) {
     super(paraview);
     this.length = length;
@@ -72,6 +73,7 @@ export abstract class AxisRule extends View {
     const line = this._orientation + fixed`${length}`;
     return svg`
       <path
+        id=${this.darken ? 'grid-zero' : ''}
         class=${this._class}
         d=${move + ' ' + line}
       ></path>
@@ -89,8 +91,8 @@ export abstract class HorizRule extends AxisRule {
    * @param _pointsTo - The tick starts on the axis and points in this direction.
    * @param major 
    */
-  constructor(protected _pointsTo: VertDirection, paraview: ParaView, major = true, length: number) {
-    super(paraview, major, length, 'v');
+  constructor(protected _pointsTo: VertDirection, paraview: ParaView, major = true, length: number, darken: boolean = false) {
+    super(paraview, major, length, 'v', darken);
   }
 
   get length() {
@@ -121,8 +123,8 @@ export abstract class VertRule extends AxisRule {
    * @param _pointsTo - The tick starts on the axis and points in this direction.
    * @param major 
    */
-  constructor(protected _pointsTo: HorizDirection, paraview: ParaView, major = true, length: number) {
-    super(paraview, major, length, 'h');
+  constructor(protected _pointsTo: HorizDirection, paraview: ParaView, major = true, length: number, darken: boolean = false) {
+    super(paraview, major, length, 'h', darken);
   }
 
   get length() {

--- a/lib/view/tickstrip.ts
+++ b/lib/view/tickstrip.ts
@@ -24,6 +24,7 @@ import { mapn } from '@fizz/chart-classifier-utils';
 
 import { svg, type TemplateResult } from 'lit';
 import { HorizGridLine, HorizTick, VertGridLine, VertTick } from './rule';
+import { Label } from './label';
 
 /**
  * A strip of tick marks.
@@ -132,7 +133,7 @@ export class HorizTickStrip extends TickStrip<'horiz'> {
     const xs = indices.map(i => isOrthoEast
       ? this.width - i*this._interval
       : i*this._interval);
-    const zeroIndex = indices.length - this.axis.tickLabelTiers[0].tickLabels.indexOf("0")
+    const zeroIndex = indices.length - this.axis.tickLabelTiers[0].children.findIndex((c: Label) => c.text == "0")
     indices.forEach((idx, i) => {
       this.append(new HorizTick(
         this.axis.orientationSettings.position, this.paraview, idx % this._majorModulus === 0, tickLength));   
@@ -187,7 +188,7 @@ export class VertTickStrip extends TickStrip<'vert'> {
     }
     const ys = indices.map(i => isNorth ?
       this.height - i*this._interval : i*this._interval);
-    const zeroIndex = indices.length - this.axis.tickLabelTiers[0].tickLabels.indexOf("0")
+    const zeroIndex = indices.length - this.axis.tickLabelTiers[0].children.findIndex((c: Label) => c.text == "0")
     indices.forEach(i => {
       this.append(new VertTick(
         this.axis.orientationSettings.position, this.paraview, i % this._majorModulus === 0, tickLength));

--- a/lib/view/tickstrip.ts
+++ b/lib/view/tickstrip.ts
@@ -132,6 +132,7 @@ export class HorizTickStrip extends TickStrip<'horiz'> {
     const xs = indices.map(i => isOrthoEast
       ? this.width - i*this._interval
       : i*this._interval);
+    const zeroIndex = indices.length - this.axis.tickLabelTiers[0].tickLabels.indexOf("0")
     indices.forEach((idx, i) => {
       this.append(new HorizTick(
         this.axis.orientationSettings.position, this.paraview, idx % this._majorModulus === 0, tickLength));   
@@ -139,7 +140,7 @@ export class HorizTickStrip extends TickStrip<'horiz'> {
       this._children.at(-1)!.y = y;
       this._children.at(-1)!.hidden = !this.axis.settings.tick.isDrawEnabled;
       this.append(new HorizGridLine(
-        this.axis.orientationSettings.position, this.paraview, undefined, this._gridLineLength));
+        this.axis.orientationSettings.position, this.paraview, undefined, this._gridLineLength, i == zeroIndex ? true : false));
       this._children.at(-1)!.x = xs[i];
       this._children.at(-1)!.y = y;
       this._children.at(-1)!.hidden = !this.paraview.store.settings.grid.isDrawVertLines;
@@ -186,6 +187,7 @@ export class VertTickStrip extends TickStrip<'vert'> {
     }
     const ys = indices.map(i => isNorth ?
       this.height - i*this._interval : i*this._interval);
+    const zeroIndex = indices.length - this.axis.tickLabelTiers[0].tickLabels.indexOf("0")
     indices.forEach(i => {
       this.append(new VertTick(
         this.axis.orientationSettings.position, this.paraview, i % this._majorModulus === 0, tickLength));
@@ -193,7 +195,7 @@ export class VertTickStrip extends TickStrip<'vert'> {
       this._children.at(-1)!.y = ys[i];
       this._children.at(-1)!.hidden = !this.axis.settings.tick.isDrawEnabled;
       this.append(new VertGridLine(
-        this.axis.orientationSettings.position, this.paraview, undefined, this._gridLineLength));
+        this.axis.orientationSettings.position, this.paraview, undefined, this._gridLineLength, i == zeroIndex ? true : false));
       this._children.at(-1)!.x = x;
       this._children.at(-1)!.y = ys[i];
       this._children.at(-1)!.hidden = !this.paraview.store.settings.grid.isDrawHorizLines;


### PR DESCRIPTION
Fixes display of `BarChart`s with negative value bars, via changes to `BarChart.addedToParent()`, and `Bar.computeLocation()`.

Fixes #299 via changes in `HorizTickStrip._createRules()` and `VertTickStrip._createRules()`. They will detect if a grid line matches a label with "0" as it's text, and pass through the `darken` flag, which will attach the `grid-zero` id to the element.
Adds style for zero axes lines in Paraview styles block

Also adds contrast values for the pattern palette because I forgot to do that.