### PR TITLE
Add stories with different settings

### DIFF
--- a/src/stories/lineMultiFeatures.stories.ts
+++ b/src/stories/lineMultiFeatures.stories.ts
@@ -1,0 +1,27 @@
+import { Settings } from '../../lib/store/settings_types';
+import { defaults } from '../../lib/store/settings_defaults';
+import { Chart, type ChartProps } from './Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Chart",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const FeaturesChart0: Story = {
+  name: "Multi-series Line Chart with Legend and No Symbols",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-16.json",
+    forcecharttype: "line",
+    config: {
+      'chart.hasDirectLabels': false,
+      'chart.isDrawSymbols': false,
+      'legend.isAlwaysDrawLegend': true
+    }
+  }
+}


### PR DESCRIPTION
Adds an example story which shows how stories with non-default settings can be added.

Specifically adds a multi-series line chart with a legend instead of direct labels and without symbols.