### PR TITLE
Fixed graphing demo with storyboook

### DIFF
--- a/etc/paracharts.api.md
+++ b/etc/paracharts.api.md
@@ -140,6 +140,8 @@ export class ParaChart extends ParaChart_base {
     // (undocumented)
     showAriaLiveHistory(): void;
     // (undocumented)
+    get slotted(): HTMLElement[];
+    // (undocumented)
     static styles: CSSResult[];
     // Warning: (ae-forgotten-export) The symbol "DeepReadonly" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "Settings" needs to be exported by the entry point index.d.ts

--- a/lib/parachart/parachart.ts
+++ b/lib/parachart/parachart.ts
@@ -183,6 +183,10 @@ export class ParaChart extends logging(ParaComponent) {
     return this._ariaLiveRegionRef.value!;
   }
 
+  get slotted(){
+    return this._slotted;
+  }
+  
   connectedCallback() {
     super.connectedCallback();
   }

--- a/lib/view/layers/data/chart_type/calculator.ts
+++ b/lib/view/layers/data/chart_type/calculator.ts
@@ -98,7 +98,7 @@ export class GraphingCalculator extends LineChart {
   }
 
   addEquation(eq: string) {
-    var container = document.querySelector('#data');
+    var container = this.paraview.paraChart.slotted[0]
     var table = document.createElement("table");
     var trVar = document.createElement("tr");
     var xVar = document.createElement("td");

--- a/src/stories/graphingCalculator.stories.ts
+++ b/src/stories/graphingCalculator.stories.ts
@@ -1,0 +1,25 @@
+import { Settings } from '../../lib/store/settings_types';
+import { defaults } from '../../lib/store/settings_defaults';
+import { Chart, type ChartProps } from './Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Chart",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const GraphingCalculator0: Story = {
+  name: "Graphing Calculator",
+  args: {
+    filename: "",
+    //@ts-ignore
+    forcecharttype: "graph",
+    config: {
+    }
+  }
+}


### PR DESCRIPTION
Gets the `<para-chart>` through `paraview` instead of using `document` selectors. #321 
Adds `graphingCalculator.stories.ts`