### PR TITLE
Add sequence landings.

### DIFF
--- a/etc/paracharts.api.md
+++ b/etc/paracharts.api.md
@@ -41,6 +41,7 @@ import { RefDirective } from 'lit-html/directives/ref.js';
 import * as sb from '@fizz/sparkbraille-component';
 import { SequenceInfo } from '@fizz/series-analyzer';
 import { Series } from '@fizz/paramodel';
+import { SeriesAnalysis } from '@fizz/series-analyzer';
 import { SeriesAnalyzerConstructor } from '@fizz/paramodel';
 import { Size2d } from '@fizz/chart-classifier-utils';
 import { State } from '@lit-app/state';

--- a/lib/store/parastore.ts
+++ b/lib/store/parastore.ts
@@ -115,6 +115,7 @@ export class ParaStore extends State {
   @property() annotations: BaseAnnotation[] = [];
   @property() sparkBrailleInfo: SparkBrailleInfo | null = null;
   @property() navNode: NavNode | null = null;
+  @property() seriesAnalyses: Record<string, SeriesAnalysis | null> = {};
 
   @property() protected data: AllSeriesData | null = null;
   @property() protected focused = 'chart';
@@ -265,6 +266,12 @@ export class ParaStore extends State {
     } else {
       throw new Error('store lacks external or inline chart data');
     }
+    this._model.keys.forEach(async seriesKey => {
+      this.seriesAnalyses = {
+        [seriesKey]: await this._model!.getSeriesAnalysis(seriesKey),
+        ...this.seriesAnalyses
+      };
+    });
   }
 
   protected _propertyChanged(key: string, value: any) {

--- a/lib/view/layers/data/chart_type/pie.ts
+++ b/lib/view/layers/data/chart_type/pie.ts
@@ -10,7 +10,7 @@ export class PieChart extends RadialChart {
     super(paraview, index);
   }
 
-  protected _playSeriesRiff() {
+  protected _playRiff() {
   }
 
   protected _createSlice(seriesView: SeriesView, params: RadialDatapointParams): RadialSlice {

--- a/lib/view/layers/data/chart_type/xy_chart.ts
+++ b/lib/view/layers/data/chart_type/xy_chart.ts
@@ -177,19 +177,18 @@ export abstract class XYChart extends DataLayer {
     });
   }
 
-  _playSeriesRiff() {
+  protected _playRiff() {
     if (this.paraview.store.settings.sonification.isSoniEnabled
       && this.paraview.store.settings.sonification.isRiffEnabled) {
-      // copy the array of datapoints so we can safely mutate it
-      const seriesDatapoints = [...this._navMap.cursor.at(0)!.series.datapoints];
-      const noteCount = seriesDatapoints.length;
+      const datapoints = this._navMap.cursor.datapointViews.map(view => view.datapoint) ;
+      const noteCount = datapoints.length;
       if (noteCount) {
         if (this._soniRiffInterval!) {
           clearInterval(this._soniRiffInterval!);
         }
         this.soniSequenceIndex++;
         this._soniRiffInterval = setInterval(() => {
-          const datapoint = seriesDatapoints.shift();
+          const datapoint = datapoints.shift();
           if (!datapoint) {
             clearInterval(this._soniRiffInterval!);
           } else {
@@ -201,7 +200,7 @@ export abstract class XYChart extends DataLayer {
     }
   }
 
-  _playDatapoints(datapoints: PlaneDatapoint[]): void {
+  protected _playDatapoints(datapoints: PlaneDatapoint[]): void {
     this.sonifier.playDatapoints(...datapoints);
   }
 

--- a/lib/view/layers/data/data_layer.ts
+++ b/lib/view/layers/data/data_layer.ts
@@ -234,13 +234,14 @@ export abstract class DataLayer extends ChartLayer {
       if (node.type === 'datapoint') {
         datapoint = node.at(0)!.datapoint;
       }
-
-      const stats = this.paraview.store.model!.atKey(seriesKey)!.getFacetStats('y')!
+      const depKey = this.paraview.store.model!.dependentFacetKey!;
+      const stats = this.paraview.store.model!.atKey(seriesKey)!.getFacetStats(depKey)!;
       let seriesMatchArray = isMin
         ? stats.min.datapoints
         : stats.max.datapoints;
       if (datapoint && seriesMatchArray.length > 1) {
-        // TODO: If there is more than one datapoint that has the same series minimum value, find the next one to nav to:
+        // TODO: If there is more than one datapoint that has the same series minimum value,
+        //       find the next one to nav to:
         //       Find the current x label, if it matches one in `seriesMins`,
         //       remove all entries up to and including that point,
         //       and use the next item on the list.
@@ -259,7 +260,7 @@ export abstract class DataLayer extends ChartLayer {
 
   /**
    * Navigate to (one of) the chart minimum/maximum datapoint(s)
-   * @param isMin If true, go the the minimum. Otherwise, go to the maximum
+   * @param isMin - If true, go the the minimum. Otherwise, go to the maximum
    */
   goChartMinMax(isMin: boolean) {
     const stats = this.paraview.store.model!.getFacetStats('y')!;
@@ -288,7 +289,8 @@ export abstract class DataLayer extends ChartLayer {
    */
   abstract playDir(dir: HorizDirection): void;
 
-  protected abstract _playSeriesRiff(): void;
+  /** Play a riff for the current nav node */
+  protected abstract _playRiff(): void;
 
   protected abstract _playDatapoints(datapoints: Datapoint[]): void;
 
@@ -362,9 +364,7 @@ export abstract class DataLayer extends ChartLayer {
         this._raiseSeries(seriesKey);
         this.paraview.store.announce(
           await this.paraview.summarizer.getSeriesSummary(seriesKey));
-        //if (!isNewComponentFocus) {
-        this._playSeriesRiff();
-        //}
+        this._playRiff();
         this.paraview.store.sparkBrailleInfo = this._sparkBrailleInfo();
       } else if (node.type === 'datapoint') {
         this._raiseSeries(seriesKey);
@@ -389,6 +389,8 @@ export abstract class DataLayer extends ChartLayer {
         if (this.paraview.store.settings.sonification.isSoniEnabled) { // && !isNewComponentFocus) {
           this._playDatapoints(node.datapointViews.map(view => view.datapoint));
         }
+      } else if (node.type === 'sequence') {
+        this._playRiff();
       }
     }
     super.storeDidChange(key, value);

--- a/lib/view/layers/data/navigation.ts
+++ b/lib/view/layers/data/navigation.ts
@@ -12,13 +12,14 @@ const oppositeDirs: Record<Direction, Direction> = {
   out: 'in'
 };
 
-export type NavNodeType = 'top' | 'series' | 'datapoint' | 'chord';
+export type NavNodeType = 'top' | 'series' | 'datapoint' | 'chord' | 'sequence';
 
 export type NavNodeOptionsType<T extends NavNodeType> =
   T extends 'top' ? TopNavNodeOptions :
   T extends 'series' ? SeriesNavNodeOptions :
   T extends 'datapoint' ? DatapointNavNodeOptions :
   T extends 'chord' ? ChordNavNodeOptions :
+  T extends 'sequence' ? SequenceNavNodeOptions :
   never;
 
 export interface TopNavNodeOptions {}
@@ -30,6 +31,12 @@ export interface DatapointNavNodeOptions {
   index: number;
 }
 export interface ChordNavNodeOptions {}
+export interface SequenceNavNodeOptions {
+  seriesKey: string;
+  // start and end as in series analysis fields
+  start: number;
+  end: number;
+}
 
 function nodeOptionsEq<T extends NavNodeType>(
   options1: NavNodeOptionsType<T>,


### PR DESCRIPTION
Closes #337.

Notable aspects of this PR:
- Adds a `seriesAnalyses` property to the store that (in AI mode) holds references to the generated series analysis data. The analyses are generated asynchronously, which is a bit awkward for the synchronous chart creation process, but by watching for changes to the `seriesAnalyses` property of the store, the chart can asynchronously add series sequence landings when the analyses they depend on become available.
- The sequence landings are accessible from datapoints by navigating `out`. For points that belong to two sequences, `out` always goes to the left sequence, and `in` to the right one. Navigating `in` from a sequence landing goes to the first point of the sequence.
- Riffs have been generalized, so sequences also have riffs.