### PR TITLE
Improve graphing calculator

### DIFF
--- a/lib/store/settings_defaults.ts
+++ b/lib/store/settings_defaults.ts
@@ -349,10 +349,9 @@ export const defaults: Settings = {
       },
       isDrawSymbols: false,
       equation: '',
-      xMin: -10,
-      xMax: 10,
       preset: '',
-      renderPts: 100
+      renderPts: 50,
+      resetAxes: false
     }
   },
   grid: {

--- a/lib/store/settings_types.ts
+++ b/lib/store/settings_types.ts
@@ -338,10 +338,9 @@ export interface HistogramSettings extends PointSettings {
 
 export interface GraphSettings extends LineSettings{
   equation: string;
-  xMin: number;
-  xMax: number;
   preset: string;
   renderPts: number;
+  resetAxes: boolean;
 }
 
 

--- a/lib/view/layers/data/chart_type/calculator.ts
+++ b/lib/view/layers/data/chart_type/calculator.ts
@@ -7,8 +7,6 @@ import { parse, simplify } from "mathjs";
 import { html } from "lit";
 
 export class GraphingCalculator extends LineChart {
-  //protected xMin: number = -10;
-  //protected xMax: number = 10;
   protected renderPts: number = 100;
   protected currEquations: string[] = [];
   protected _addedToParent() {
@@ -115,8 +113,8 @@ export class GraphingCalculator extends LineChart {
     });
 
     this._axisInfo = new AxisInfo(this.paraview.store, {
-      xValues: [this.paraview.store.settings.axis.x.minValue == "unset" ? -10 : this.paraview.store.settings.type.graph.xMin /*?? this.xMin*/, 
-        this.paraview.store.settings.axis.x.maxValue == "unset" ? 10 : this.paraview.store.settings.type.graph.xMax /*?? this.xMax*/],
+      xValues: [this.paraview.store.settings.axis.x.minValue == "unset" ? -10 : this.paraview.store.settings.type.graph.xMin, 
+        this.paraview.store.settings.axis.x.maxValue == "unset" ? 10 : this.paraview.store.settings.type.graph.xMax],
       yValues: [-10, 10],
       yMin: -10,
       yMax: 10
@@ -160,8 +158,8 @@ export class GraphingCalculator extends LineChart {
 
   addEquation(eq: string) {
     this._axisInfo = new AxisInfo(this.paraview.store, {
-      xValues: [this.paraview.store.settings.axis.x.minValue == "unset" ? -10 : this.paraview.store.settings.type.graph.xMin /*?? this.xMin*/,
-      this.paraview.store.settings.axis.x.maxValue == "unset" ? 10 : this.paraview.store.settings.type.graph.xMax /*?? this.xMax*/],
+      xValues: [this.paraview.store.settings.axis.x.minValue == "unset" ? -10 : this.paraview.store.settings.type.graph.xMin,
+      this.paraview.store.settings.axis.x.maxValue == "unset" ? 10 : this.paraview.store.settings.type.graph.xMax],
       yValues: [-10, 10],
       yMin: -10,
       yMax: 10

--- a/lib/view/layers/data/chart_type/calculator.ts
+++ b/lib/view/layers/data/chart_type/calculator.ts
@@ -4,14 +4,68 @@ import { LineChart, LineSection } from "./line_chart";
 import { XYSeriesView } from "./xy_chart";
 import { AxisInfo } from "../../../../common/axisinfo";
 import { parse, simplify } from "mathjs";
+import { html } from "lit";
 
 export class GraphingCalculator extends LineChart {
-  protected xMin: number = -10;
-  protected xMax: number = 10;
+  //protected xMin: number = -10;
+  //protected xMax: number = 10;
   protected renderPts: number = 100;
   protected currEquations: string[] = [];
   protected _addedToParent() {
     super._addedToParent();
+    this.paraview.store.settingControls.add({
+      type: 'textfield',
+      key: 'axis.x.minValue',
+      label: 'Min x-value',
+      options: { inputType: 'number' },
+      value: -10,
+      validator: value => {
+        const min = this.paraview.store.settings.axis.x.maxValue == "unset" 
+          ? 10
+          : this.paraview.store.settings.axis.x.maxValue as number
+        // NB: If the new value is successfully validated, the inner chart
+        // gets recreated, and `max` may change, due to re-quantization of
+        // the tick values. 
+        return value as number >= min ?
+          { err: `Min y-value (${value}) must be less than (${min})`} : {};
+      },
+      parentView: 'controlPanel.tabs.chart.general',
+    });
+    this.paraview.store.settingControls.add({
+      type: 'textfield',
+      key: 'axis.x.maxValue',
+      label: 'Max x-value',
+      options: { inputType: 'number' },
+      value: 10,
+      validator: value => {
+        const max = this.paraview.store.settings.axis.x.minValue == "unset" 
+          ? -10
+          : this.paraview.store.settings.axis.x.minValue as number
+        // NB: If the new value is successfully validated, the inner chart
+        // gets recreated, and `max` may change, due to re-quantization of
+        // the tick values. 
+        return value as number <= max ?
+          { err: `Min y-value (${value}) must be less than (${max})`} : {};
+      },
+      parentView: 'controlPanel.tabs.chart.general',
+    });
+/*
+    let panel = this.paraview.paraChart.getElementsByTagName('para-chart-panel')[0]
+    console.log(this.paraview.paraChart)
+    console.log(panel)
+    let resetButton = document.createElement('button');
+    resetButton.innerHTML = `<button
+            @click=${() => {
+              this._axisInfo = new AxisInfo(this.paraview.store, {
+                xValues: [-10, 10],
+                yValues: [-10, 10]
+              })
+            }}
+          >
+            Save data
+          </button>`
+    panel.append(resetButton)
+*/
     this.paraview.store.settingControls.add({
       type: 'textfield',
       key: 'type.graph.lineWidth',
@@ -27,19 +81,6 @@ export class GraphingCalculator extends LineChart {
       type: 'checkbox',
       key: 'type.graph.isDrawSymbols',
       label: 'Show symbols',
-      parentView: 'controlPanel.tabs.chart.chart',
-    });
-
-
-    this.paraview.store.settingControls.add({
-      type: 'textfield',
-      key: 'type.graph.lineWidth',
-      label: 'Line width',
-      options: {
-        inputType: 'number',
-        min: 1,
-        max: this.paraview.store.settings.type.graph.lineWidthMax as number
-      },
       parentView: 'controlPanel.tabs.chart.chart',
     });
 
@@ -74,7 +115,8 @@ export class GraphingCalculator extends LineChart {
     });
 
     this._axisInfo = new AxisInfo(this.paraview.store, {
-      xValues: [this.paraview.store.settings.type.graph.xMin ?? this.xMin, this.paraview.store.settings.type.graph.xMax ?? this.xMax],
+      xValues: [this.paraview.store.settings.axis.x.minValue == "unset" ? -10 : this.paraview.store.settings.type.graph.xMin /*?? this.xMin*/, 
+        this.paraview.store.settings.axis.x.maxValue == "unset" ? 10 : this.paraview.store.settings.type.graph.xMax /*?? this.xMax*/],
       yValues: [-10, 10],
       yMin: -10,
       yMax: 10
@@ -83,6 +125,9 @@ export class GraphingCalculator extends LineChart {
 
   settingDidChange(path: string, oldValue?: Setting, newValue?: Setting): void {
     if (['type.graph.equation'].includes(path)) {
+      this.paraview.store.clearVisited();
+      this.paraview.store.clearSelected();
+      this.paraview.store.sparkBrailleInfo = null;
       this.addEquation(newValue as string);
     }
     else if (['type.graph.preset'].includes(path)) {
@@ -91,13 +136,36 @@ export class GraphingCalculator extends LineChart {
           });
     }
     else if (['type.graph.renderPts'].includes(path)) {
+      this.paraview.store.clearVisited();
+      this.paraview.store.clearSelected();
+      this.paraview.store.sparkBrailleInfo = null;
       this.renderPts = Number(newValue)
+      this.addEquation(this.paraview.store.settings.type.graph.equation)
+    }
+    else if (['axis.x.maxValue', 'axis.x.minValue'].includes(path)){
+      if (path === 'axis.x.maxValue'){
+        this.paraview.store.updateSettings(draft => {
+            draft.type.graph.xMax = Number(newValue);
+          });
+      }
+      else if (path === 'axis.x.minValue'){
+        this.paraview.store.updateSettings(draft => {
+            draft.type.graph.xMin = Number(newValue);
+          });
+      }
       this.addEquation(this.paraview.store.settings.type.graph.equation)
     }
     super.settingDidChange(path, oldValue, newValue);
   }
 
   addEquation(eq: string) {
+    this._axisInfo = new AxisInfo(this.paraview.store, {
+      xValues: [this.paraview.store.settings.axis.x.minValue == "unset" ? -10 : this.paraview.store.settings.type.graph.xMin /*?? this.xMin*/,
+      this.paraview.store.settings.axis.x.maxValue == "unset" ? 10 : this.paraview.store.settings.type.graph.xMax /*?? this.xMax*/],
+      yValues: [-10, 10],
+      yMin: -10,
+      yMax: 10
+    })
     var container = this.paraview.paraChart.slotted[0]
     var table = document.createElement("table");
     var trVar = document.createElement("tr");
@@ -119,12 +187,13 @@ export class GraphingCalculator extends LineChart {
       var xVals = [];
       var yVals = [];
       const points = this.renderPts
-      const xBounds = 10
+      const xMax = this.axisInfo!.xLabelInfo!.max ?? 10
+      const xMin = this.axisInfo!.xLabelInfo!.min ?? -10
       for (var i = 0; i < points + 1; i++) {
         var tr = document.createElement("tr");
         var td1 = document.createElement("td");
         var td2 = document.createElement("td");
-        var xVal = parseFloat((i / (points / (2 * xBounds)) - xBounds).toFixed(3))
+        var xVal = parseFloat((i / (points / ((xMax - xMin))) + (xMin)).toFixed(3))
         const simpEval = simplified.evaluate({ x: xVal })
         if (simpEval.im === undefined){
           var yVal = simpEval.toFixed(3);
@@ -145,10 +214,10 @@ export class GraphingCalculator extends LineChart {
         }
         container.append(table);
         this.paraview.store.updateSettings(draft => {
-            draft.type.graph.xMax = xBounds;
+            draft.type.graph.xMax = xMax;
           });
         this.paraview.store.updateSettings(draft => {
-            draft.type.graph.xMin = -1 * xBounds;
+            draft.type.graph.xMin = xMin;
           });
         this.paraview.dispatchEvent(new CustomEvent('paraviewready', {bubbles: true, composed: true, cancelable: true}));
       }
@@ -185,6 +254,25 @@ export class GraphingCalculator extends LineChart {
 
   protected _newDatapointView(seriesView: XYSeriesView) {
     return new GraphLine(seriesView);
+  }
+
+  protected _sparkBrailleInfo() {
+    let data = this._navMap.cursor.datapointViews[0].series.datapoints.map(dp =>
+      dp.facetValueAsNumber('y')!).join(' ')
+    //Sparkbrailles with more than 50 points either get cut off by the edge of the panel, or push the panel outwards and make it look bad
+    if (this._navMap.cursor.datapointViews[0].series.datapoints.length > 50) {
+      const length = this._navMap.cursor.datapointViews[0].series.datapoints.length
+      let indices = []
+      for (let i = 0; i < 50; i++) {
+        indices.push(Math.floor(i * length / 50))
+      }
+      data = this._navMap.cursor.datapointViews[0].series.datapoints.filter((e, index) => { return indices.includes(index); }).map(dp =>
+        dp.facetValueAsNumber('y')!).join(' ');
+    }
+    return {
+      data: data,
+      isBar: this.paraview.store.type === 'bar' || this.paraview.store.type === 'column'
+    };
   }
 }
 


### PR DESCRIPTION
-Removes previously added xMin and xMax settings, consolidates that within the existing `axisInfo.x.Max` and `axisInfo.x.Min`
-Clears sparkbraille upon changing equation to force it to update, limits max size to 50 for readability, see #328 
-Added button under Chart tab to reset axes to defaults (currently -10 to 10 for both x and y)
-Changed default rendering points from 100 to 50
-Fixes bugs with selected and visited points by clearing them before changing equations
