### PR TITLE
Sam linebreak annotations

### DIFF
--- a/lib/control_panel/tab_panels/annotation.ts
+++ b/lib/control_panel/tab_panels/annotation.ts
@@ -59,7 +59,6 @@ export class AnnotationPanel extends ControlPanelTabPanel {
 
   protected _selectAnnotation(event: Event) {
     const target = (event?.target as HTMLElement);
-    console.log(target)
     if (target) {
       this._highlightAnnotation(target);
       if (target.dataset.series && target.dataset.index!) {

--- a/lib/control_panel/tab_panels/annotation.ts
+++ b/lib/control_panel/tab_panels/annotation.ts
@@ -59,6 +59,7 @@ export class AnnotationPanel extends ControlPanelTabPanel {
 
   protected _selectAnnotation(event: Event) {
     const target = (event?.target as HTMLElement);
+    console.log(target)
     if (target) {
       this._highlightAnnotation(target);
       if (target.dataset.series && target.dataset.index!) {
@@ -95,6 +96,29 @@ export class AnnotationPanel extends ControlPanelTabPanel {
             }
           >
             Add Annotation
+          </button>
+        </div>
+        <div> 
+          <button
+            @click=${
+              () => {
+                this._store.addUserLineBreaks()
+              }
+            }
+          >
+            Add Line breaks
+          </button>
+        </div>
+         <div>
+          <button
+            @click=${
+              () => {
+                this._store.clearUserLineBreaks()
+                this._store.clearUserTrendLines()
+              }
+            }
+          >
+            Remove added line breaks
           </button>
         </div>
          <div>

--- a/lib/paraview/hotkey_actions.ts
+++ b/lib/paraview/hotkey_actions.ts
@@ -27,6 +27,7 @@ export interface AvailableActions {
   chordModeToggle(): void;
   shutUp(): void;
   repeatLastAnnouncement(): void;
+  addAnnotation(): void;
 }
 
 
@@ -158,6 +159,9 @@ export class HotkeyActions {
       repeatLastAnnouncement() {
         paraView.paraChart.ariaLiveRegion.replay();
       },
+      addAnnotation() {
+        store.addAnnotation();
+      }
     };
   }
 

--- a/lib/paraview/paraview.ts
+++ b/lib/paraview/paraview.ts
@@ -204,7 +204,17 @@ export class ParaView extends logging(ParaComponent) {
       .linebreaker-marker {
         fill: hsl(0, 17.30%, 37.50%);
       }
+      .user-linebreaker-marker {
+        fill: hsl(0, 87%, 48%);
+      }
       .trend-line{
+        display: inline;
+        stroke-width: 8px;
+        stroke-linecap: butt;
+        stroke-dasharray: 12 12;
+        stroke-opacity: 0.8;
+      }
+      .user-trend-line{
         display: inline;
         stroke-width: 8px;
         stroke-linecap: butt;

--- a/lib/store/keymap.ts
+++ b/lib/store/keymap.ts
@@ -101,11 +101,11 @@ export const keymap: KeyRegistrations = {
     caseSensitive: false,
     action: 'selectClear'
   },
-  // a: {
-  //   label: 'Add an annotation',
-  //   caseSensitive: false,
-  //   action: 'add_annotation'
-  // },
+  a: {
+    label: 'Add an annotation',
+    caseSensitive: false,
+    action: 'addAnnotation'
+  },
   // 'Ctrl+ArrowLeft': {
   //   action: 'previous_tenth'
   // },

--- a/lib/store/parastore.ts
+++ b/lib/store/parastore.ts
@@ -86,6 +86,8 @@ export interface RangeHighlight {
 
 export interface LineBreak {
   startPortion: number;
+  index: number;
+  seriesKey: string;
 }
 
 export interface TrendLine {
@@ -118,8 +120,10 @@ export class ParaStore extends State {
   @property() protected _selectedDatapoints: DataCursor[] = [];
   @property() protected _prevSelectedDatapoints: DataCursor[] = [];
   @property() protected _rangeHighlights: RangeHighlight[] = [];
-  @property() protected _lineBreaks: LineBreak[] = [];
-  @property() protected _trendLines: TrendLine[] = [];
+  @property() protected _modelLineBreaks: LineBreak[] = [];
+  @property() protected _userLineBreaks: LineBreak[] = [];
+  @property() protected _modelTrendLines: TrendLine[] = [];
+  @property() protected _userTrendLines: TrendLine[] = [];
 
   protected _settingControls = new SettingControlManager(this); 
   protected _settingObservers: { [path: string]: SettingObserver[] } = {};
@@ -194,12 +198,20 @@ export class ParaStore extends State {
     return this._rangeHighlights;
   }
 
-  get lineBreaks() {
-    return this._lineBreaks
+  get modelLineBreaks() {
+    return this._modelLineBreaks;
   }
 
-  get trendLines() {
-    return this._trendLines
+  get userLineBreaks() {
+    return this._userLineBreaks;
+  }
+
+  get modelTrendLines() {
+    return this._modelTrendLines;
+  }
+
+  get userTrendLines() {
+    return this._userTrendLines;
   }
 
   setManifest(manifest: Manifest, data?: AllSeriesData) {
@@ -667,9 +679,9 @@ export class ParaStore extends State {
     const series = this.model!.series.filter(s => s[0].seriesKey == seriesKey)[0]
     const length = series.length - 1
     for (let seq of sequences) {
-      this.addLineBreak(seq.start / length, seriesKey)
+      this.addLineBreak(seq.start / length, seq.start, seriesKey, true)
     }
-    this.addLineBreak((sequences[sequences.length - 1].end - 1) / length, seriesKey)
+    this.addLineBreak((sequences[sequences.length - 1].end - 1) / length, sequences[sequences.length - 1].end - 1, seriesKey, true)
 
   }
 
@@ -677,50 +689,100 @@ export class ParaStore extends State {
     const series = this.model!.series.filter(s => s[0].seriesKey == seriesKey)[0]
     const length = series.length - 1
     for (let seq of sequences) {
-      const index = this._lineBreaks.findIndex(lb =>
+      const index = this._modelLineBreaks.findIndex(lb =>
         lb.startPortion === seq.start / length);
       if (index === -1) {
         //throw new Error('range not highlighted');
       }
       else {
-        this._lineBreaks = this._lineBreaks.toSpliced(index, 1);
+        this._modelLineBreaks = this._modelLineBreaks.toSpliced(index, 1);
       }
     }
-    const index = this._lineBreaks.findIndex(lb =>
+    const index = this._modelLineBreaks.findIndex(lb =>
       lb.startPortion === (sequences[sequences.length - 1].end - 1) / length);
     if (index === -1) {
       //throw new Error('range not highlighted');
     }
     else {
-      this._lineBreaks = this._lineBreaks.toSpliced(index, 1);
+      this._modelLineBreaks = this._modelLineBreaks.toSpliced(index, 1);
     }
   }
 
-  addLineBreak(startPortion: number, seriesKey: string) {
-    if (this._lineBreaks.find(lb =>
-      lb.startPortion === startPortion)) {
-      //throw new Error('range already highlighted');
+  addLineBreak(startPortion: number, index: number, seriesKey: string, forModel: boolean) {
+    if (forModel) {
+      if (this._modelLineBreaks.find(lb =>
+        lb.startPortion === startPortion)) {
+        //throw new Error('range already highlighted');
+      }
+      else {
+        this._modelLineBreaks = [...this._modelLineBreaks, { startPortion: startPortion, seriesKey: seriesKey, index: index }];
+      }
     }
-    else {
-      this._lineBreaks = [...this._lineBreaks, { startPortion: startPortion }];
+    else{
+      if (this._userLineBreaks.find(lb =>
+        lb.startPortion === startPortion && lb.seriesKey === seriesKey)) {
+        //throw new Error('range already highlighted');
+      }
+      else {
+        this._userLineBreaks = [...this._userLineBreaks, { startPortion: startPortion, seriesKey: seriesKey, index: index   }];
+      }
     }
   }
+
+  addUserLineBreaks() {
+    for (let point of this.selectedDatapoints) {
+      const series = this.model!.series.filter(s => s[0].seriesKey == point.seriesKey)[0]
+      const length = series.length - 1
+      this.addLineBreak(point.index / length, point.index, point.seriesKey, false)
+      this.annotations.push({
+        seriesKey: point.seriesKey,
+        index: point.index,
+        annotation: `${series.key}, ${series.rawData[point.index].x}: Added line break`,
+        id: `line-break-${point.index}`
+      })
+    }
+    if (this.userLineBreaks.length) {
+      this.clearUserTrendLines();
+      for (let seriesKey of new Set(this.userLineBreaks.map(a => { return a.seriesKey }))) {
+        let lbs = this.userLineBreaks.filter(a => a.seriesKey === seriesKey).sort((a, b) => a.index - b.index)
+        this.addTrendLine(0, lbs[0].startPortion, 0, lbs[0].index + 1, seriesKey, false)
+        for (let i = 0; i < lbs.length - 1; i++) {
+          this.addTrendLine(lbs[i].startPortion, lbs[i + 1].startPortion, lbs[i].index, lbs[i + 1].index + 1, seriesKey, false)
+        }
+        const series = this.model!.series.filter(s => s[0].seriesKey == seriesKey)[0]
+        const length = series.length - 1
+        this.addTrendLine(lbs[lbs.length - 1].startPortion, 1, lbs[lbs.length - 1].index, length + 1, seriesKey, false)
+      }
+    }
+  }
+
 
   addModelTrendLines(sequences: SequenceInfo[], seriesKey: string) {
     const series = this.model!.series.filter(s => s[0].seriesKey == seriesKey)[0]
     const length = series.length - 1
     for (let seq of sequences) {
-      this.addTrendLine(seq.start / length, (seq.end - 1) / length, seq.start, seq.end, seriesKey)
+      this.addTrendLine(seq.start / length, (seq.end - 1) / length, seq.start, seq.end, seriesKey, true)
     }
   }
 
-  addTrendLine(startPortion: number, endPortion: number, startIndex: number, endIndex: number, seriesKey: string) {
-    if (this._trendLines.find(tl =>
-      tl.startPortion === startPortion && tl.endPortion === endPortion)) {
-      //throw new Error('range already highlighted');
+  addTrendLine(startPortion: number, endPortion: number, startIndex: number, endIndex: number, seriesKey: string, forModel: boolean) {
+    if (forModel) {
+      if (this._modelTrendLines.find(tl =>
+        tl.startPortion === startPortion && tl.endPortion === endPortion)) {
+        //throw new Error('range already highlighted');
+      }
+      else {
+        this._modelTrendLines = [...this._modelTrendLines, { startPortion: startPortion, endPortion: endPortion, startIndex: startIndex, endIndex: endIndex, seriesKey: seriesKey }];
+      }
     }
     else {
-      this._trendLines = [...this._trendLines, { startPortion: startPortion, endPortion: endPortion, startIndex: startIndex, endIndex: endIndex, seriesKey: seriesKey }];
+      if (this._userTrendLines.find(tl =>
+        tl.startPortion === startPortion && tl.endPortion === endPortion && tl.seriesKey === seriesKey)) {
+        //throw new Error('range already highlighted');
+      }
+      else {
+        this._userTrendLines = [...this._userTrendLines, { startPortion: startPortion, endPortion: endPortion, startIndex: startIndex, endIndex: endIndex, seriesKey: seriesKey }];
+      }
     }
   }
 
@@ -728,14 +790,23 @@ export class ParaStore extends State {
     const series = this.model!.series.filter(s => s[0].seriesKey == seriesKey)[0]
     const length = series.length - 1
     for (let seq of sequences) {
-      const index = this._trendLines.findIndex(tl =>
+      const index = this._modelTrendLines.findIndex(tl =>
         tl.startPortion === seq.start / length && tl.endPortion === (seq.end - 1) / length);
       if (index === -1) {
         //throw new Error('range not highlighted');
       }
       else {
-        this._trendLines = this._trendLines.toSpliced(index, 1);
+        this._modelTrendLines = this._modelTrendLines.toSpliced(index, 1);
       }
     }
+  }
+
+  clearUserLineBreaks() {
+    this._userLineBreaks = []
+    this.annotations = this.annotations.filter(a => !/line-break/.test(a.id))
+  }
+
+  clearUserTrendLines() {
+    this._userTrendLines = [];
   }
 }


### PR DESCRIPTION
Adds user-changeable line breaks, which automatically add trend-lines. They operate separately from the MDR annotations, and as such the LineBreak and TrendLine types are split.


Re-enables add annotation hotkey #247 