### PR TITLE
Removed the need to use a <slot> to load datatables

### DIFF
--- a/lib/parachart/parachart.ts
+++ b/lib/parachart/parachart.ts
@@ -95,10 +95,10 @@ export class ParaChart extends logging(ParaComponent) {
           this._loaderPromise = this._runLoader(this.manifest, this.manifestType).then(() => {
             this.log('ParaCharts will now commence the raising of the roof and/or the dead');
           });
-        } else if (this._slotted.length) {
+        } else if (this.getElementsByTagName("table")[0]) {
           this.log(`loading from slot`);
-          const table = this._slotted[0].getElementsByTagName("table")[0]
-          const manifest = this._slotted[0].getElementsByClassName("manifest")[0] as HTMLElement
+          const table = this.getElementsByTagName("table")[0]
+          const manifest = this.getElementsByClassName("manifest")[0] as HTMLElement
           this._store.dataState = 'pending';
           if (table) {
             const loadresult = await this._slotLoader.findManifest([table, manifest], "some-manifest")
@@ -111,6 +111,7 @@ export class ParaChart extends logging(ParaComponent) {
               this._store.dataState = 'error';
             }
           }
+        }
           else {
             console.log("No datatable in slot")
             if (this.getAttribute("type") === 'graph') {
@@ -150,7 +151,6 @@ export class ParaChart extends logging(ParaComponent) {
               this._store.dataState = 'error'
             }
           }
-        }
       });
     });
   }

--- a/lib/view/layers/data/chart_type/calculator.ts
+++ b/lib/view/layers/data/chart_type/calculator.ts
@@ -158,7 +158,7 @@ export class GraphingCalculator extends LineChart {
       yMin: -10,
       yMax: 10
     })
-    var container = this.paraview.paraChart.slotted[0]
+    var container = this.paraview.paraChart;
     var table = document.createElement("table");
     var trVar = document.createElement("tr");
     var xVar = document.createElement("td");
@@ -201,8 +201,8 @@ export class GraphingCalculator extends LineChart {
         }
       }
       if (container){
-        if(container.firstElementChild){
-          container.removeChild(container.firstElementChild);
+        if(container.getElementsByTagName('table')[0]){
+          container.removeChild(container.getElementsByTagName('table')[0]);
         }
         container.append(table);
         this.paraview.dispatchEvent(new CustomEvent('paraviewready', {bubbles: true, composed: true, cancelable: true}));

--- a/src/demo/datatable/datatable-bar-1018-demo.html
+++ b/src/demo/datatable/datatable-bar-1018-demo.html
@@ -38,7 +38,7 @@
   <h1>@fizz/paracharts Live Server Headless Demo</h1>
   <script src="./data/bar-1018.js"></script>
   <script type="module">
-    const container = document.querySelector('#data');
+    const container = document.getElementsByTagName('para-chart')[0]
     const table = document.createElement("table")
     container.append(table)
     table.innerHTML = bar_1018;
@@ -49,8 +49,6 @@
   <main>
     <section id="content-container">
       <para-chart type="bar">
-        <slot id="data">
-        </slot>
       </para-chart>
     </section>
   </main>

--- a/src/demo/datatable/datatable-line-multi-233-demo.html
+++ b/src/demo/datatable/datatable-line-multi-233-demo.html
@@ -38,7 +38,7 @@
   <h1>@fizz/paracharts Live Server Headless Demo</h1>
   <script src="./data/line-multi-233.js"></script>
   <script type="module">
-    const container = document.querySelector('#data');
+    const container = document.getElementsByTagName('para-chart')[0]
     const table = document.createElement("table")
     container.append(table)
     table.innerHTML = line_multi_233;
@@ -49,8 +49,6 @@
   <main>
     <section id="content-container">
       <para-chart type="line">
-        <slot id="data">
-        </slot>
       </para-chart>
     </section>
   </main>

--- a/src/demo/datatable/datatable-line-multi-27-demo.html
+++ b/src/demo/datatable/datatable-line-multi-27-demo.html
@@ -38,7 +38,7 @@
   <h1>@fizz/paracharts Live Server Headless Demo</h1>
   <script src="./data/line-multi-27.js"></script>
   <script type="module">
-    const container = document.querySelector('#data');
+    const container = document.getElementsByTagName('para-chart')[0]
     const table = document.createElement("table")
     container.append(table)
     table.innerHTML = line_multi_27;
@@ -49,8 +49,6 @@
   <main>
     <section id="content-container">
       <para-chart type="line">
-        <slot id="data">
-        </slot>
       </para-chart>
     </section>
   </main>

--- a/src/demo/datatable/datatable-pastry-47-demo.html
+++ b/src/demo/datatable/datatable-pastry-47-demo.html
@@ -38,7 +38,7 @@
   <h1>@fizz/paracharts Live Server Headless Demo</h1>
   <script src="./data/pastry-47.js"></script>
   <script type="module">
-    const container = document.querySelector('#data');
+    const container = document.getElementsByTagName('para-chart')[0]
     const table = document.createElement("table")
     container.append(table)
     table.innerHTML = pastry_47;
@@ -49,8 +49,6 @@
   <main>
     <section id="content-container">
       <para-chart type="pie">
-        <slot id="data">
-        </slot>
       </para-chart>
     </section>
   </main>

--- a/src/demo/datatable/datatable-scatter-demo.html
+++ b/src/demo/datatable/datatable-scatter-demo.html
@@ -38,7 +38,7 @@
   <h1>@fizz/paracharts Live Server Headless Demo</h1>
   <script src="./data/scatter-test.js"></script>
   <script type="module">
-    const container = document.querySelector('#data');
+    const container = document.getElementsByTagName('para-chart')[0]
     const table = document.createElement("table")
     container.append(table)
     table.innerHTML = scatter_test;
@@ -49,8 +49,6 @@
   <main>
     <section id="content-container">
       <para-chart type="scatter">
-        <slot id="data">
-        </slot>
       </para-chart>
     </section>
   </main>

--- a/src/demo/datatable/graphing-demo.html
+++ b/src/demo/datatable/graphing-demo.html
@@ -40,8 +40,6 @@
     <main>
         <section id="content-container">
             <para-chart type="graph">
-                <slot id="data">
-                </slot>
             </para-chart>
         </section>
     </main>


### PR DESCRIPTION
Per #394 , restructures parts of `ParaChart` constructor and parts of `GraphingCalculator.addEquation()`, also changes existing datatable demo pages to work.