### PR TITLE
Improved numeric facet typing check

### DIFF
--- a/lib/loader/slotloader.ts
+++ b/lib/loader/slotloader.ts
@@ -130,8 +130,11 @@ export class SlotLoader {
       if (/\b(year|month|day)\b/i.test(vars[i].label)) {
         facet.datatype = 'date';
       }
-      else if (/\d/.test(cols[i][0])) {
+      else if (!isNaN(Number(cols[i][0].replace('%', '')))) {
         facet.datatype = 'number';
+      }
+      else {
+        facet.datatype = 'string';
       }
     }
     return {result: 'success', manifest: manifest };


### PR DESCRIPTION
Per #397 , changes the type assumption tests in `slotloader.ts` to allow for string containing numbers to be correctly parsed as strings. There are probably more exceptions, but this works with every existing example as well as the one in the issue.