### PR TITLE
Fixed everVisitedDatapoints

### DIFF
--- a/lib/store/parastore.ts
+++ b/lib/store/parastore.ts
@@ -441,7 +441,11 @@ export class ParaStore extends State {
   visit(datapoints: DataCursor[]) {
     this._prevVisitedDatapoints = this._visitedDatapoints;
     this._visitedDatapoints = [...datapoints];
-    this._everVisitedDatapoints.push(...datapoints);
+    for (let datapoint of datapoints){
+      if (!this.everVisited(datapoint.seriesKey, datapoint.index)){
+        this._everVisitedDatapoints.push(datapoint);
+      }
+    }
     if (this.settings.controlPanel.isMDRAnnotationsVisible) {
       this.removeMDRAnnotations(this._prevVisitedDatapoints)
       this.showMDRAnnotations();


### PR DESCRIPTION
Changing it to a set would require changing the structure of the data stored, or changing the equality check mechanism, because strict === checking treats identical `DataCursor` objects as distinct. Instead this just adds a check to see if an element is already in the array before adding, which achieves the same effect. #416 