### PR TITLE
Add `manifestType` parameter to stories

### DIFF
--- a/src/stories/Chart.ts
+++ b/src/stories/Chart.ts
@@ -9,6 +9,7 @@ import '/lib-ai/index-ai.ts';
 
 export interface ChartProps {
   filename: string;
+  manifestType?: 'url' | 'fizz-chart-data';
   config?: SettingsInput;  
   forcecharttype?: ChartType;
   slot?: TemplateResult;
@@ -20,7 +21,7 @@ export interface ChartProps {
  * Primary UI component for user interaction
  */
 export const Chart = ({ 
-  filename, config, forcecharttype, slot, legendOrder, description
+  filename, config, forcecharttype, slot, legendOrder, description, manifestType
 }: ChartProps) => {
   config ??= {};
   config['controlPanel.isControlPanelDefaultOpen'] = true;
@@ -74,7 +75,7 @@ export const Chart = ({
 
   <para-chart 
     manifest=${filename}
-    manifesttype=${filename.startsWith('/') ? 'url' : 'fizz-chart-data'} 
+    manifesttype=${manifestType ?? 'fizz-chart-data'} 
     .config=${config}
     forcecharttype=${forcecharttype ?? nothing}
     type=${forcecharttype ?? nothing}
@@ -88,7 +89,7 @@ export const Chart = ({
 };
 
 export const AiChart = ({ 
-  filename, config, forcecharttype, slot, legendOrder, description
+  filename, config, forcecharttype, slot, legendOrder, description, manifestType
 }: ChartProps) => {
   config ??= {};
   config['controlPanel.isControlPanelDefaultOpen'] = true;
@@ -142,12 +143,13 @@ export const AiChart = ({
 
   <para-chart-ai 
     manifest=${filename}
-    manifesttype=${filename.startsWith('/') ? 'url' : 'fizz-chart-data'} 
+    manifesttype=${manifestType ?? 'fizz-chart-data'} 
     .config=${config}
     forcecharttype=${forcecharttype ?? nothing}
     description=${description ?? nothing}
     data-testid="para-chart"
   >
+    <slot>${slot ?? ``}</slot>
     <span slot="settings"></span>
   </para-chart-ai>
   `;


### PR DESCRIPTION
Adds a `manifestType` parameter to stories, so that loading from `chart-data` or from the actual path can be specified directly, rather than using '/' at the `filename` parameter.