### PR TITLE
Add pointer panning, zooming, and more dynamic axes for graphs

### DIFF
--- a/lib/paraview/pointermanager.ts
+++ b/lib/paraview/pointermanager.ts
@@ -11,6 +11,8 @@ interface PointerDetails {
   target: Element;
   x: number;
   y: number;
+  offsetX: number;
+  offsetY: number;
   value?: {
     x: any;
     y: any;
@@ -57,7 +59,9 @@ export class PointerEventManager {
       id: event.pointerId,
       target: event.target as SVGGraphicsElement,
       x: event.clientX,
-      y: event.clientY
+      y: event.clientY,
+      offsetX: event.offsetX,
+      offsetY: event.offsetY
     };
   }
 
@@ -77,6 +81,14 @@ export class PointerEventManager {
    * @param event - The event on the element.
    */
   handleEnd(event: PointerEvent) {
+    if (this._paraView.store.type === 'graph'){
+      let start = this._touchArray[0]
+      const startRelativeX = start.offsetX - this._paraView.documentView!.padding.left - this._paraView.documentView!.chartLayers.x
+      const startRelativeY = start.offsetY - this._paraView.documentView!.padding.top - this._paraView.documentView!.chartLayers.y
+      const endRelativeX = event.offsetX - this._paraView.documentView!.padding.left - this._paraView.documentView!.chartLayers.x
+      const endRelativeY = event.offsetY - this._paraView.documentView!.padding.top - this._paraView.documentView!.chartLayers.y
+      this._paraView.documentView!.chartLayers.dataLayer.handlePan(startRelativeX, startRelativeY, endRelativeX, endRelativeY)
+    }
     // Note: `handleEnd` is not currently used, but will be when we add marquee dragging
     this.handleCancel(event);
   }
@@ -172,6 +184,11 @@ export class PointerEventManager {
    */
   handleDoubleClick(event: PointerEvent | MouseEvent) {
     const target = event.target as SVGGraphicsElement;
+    if (this._paraView.store.type === 'graph') {
+      const endRelativeX = event.offsetX - this._paraView.documentView!.padding.left - this._paraView.documentView!.chartLayers.x
+      const endRelativeY = event.offsetY - this._paraView.documentView!.padding.top - this._paraView.documentView!.chartLayers.y
+      this._paraView.documentView!.chartLayers.dataLayer.handleZoom(endRelativeX, endRelativeY)
+    }
     event.preventDefault();
     if (target === this._paraView.root || target === this._dataRoot) {
       // this._selectElement(target);

--- a/lib/store/parastore.ts
+++ b/lib/store/parastore.ts
@@ -489,6 +489,7 @@ export class ParaStore extends State {
   }
 
   clearVisited() {
+    this._prevVisitedDatapoints = this._visitedDatapoints;
     this._visitedDatapoints = [];
   }
 
@@ -556,6 +557,7 @@ export class ParaStore extends State {
   }
 
   clearSelected() {
+    this._prevSelectedDatapoints = this._selectedDatapoints;
     this._selectedDatapoints = []
   }
 

--- a/lib/view/layers/data/chart_type/calculator.ts
+++ b/lib/view/layers/data/chart_type/calculator.ts
@@ -1,14 +1,14 @@
 import { StyleInfo } from "lit/directives/style-map.js";
-import { DataCursor, DeepReadonly, GraphSettings, LineSettings, Setting } from "../../../../store";
+import { DataCursor, DeepReadonly, Direction, GraphSettings, LineSettings, Setting } from "../../../../store";
 import { LineChart, LineSection } from "./line_chart";
 import { XYSeriesView } from "./xy_chart";
 import { AxisInfo } from "../../../../common/axisinfo";
 import { parse, simplify } from "mathjs";
-import { html } from "lit";
 import { Box, PlaneDatapoint} from "@fizz/paramodel";
 import { RiffOrder, SONI_RIFF_SPEEDS } from "../data_layer";
 import { NumberBox } from "@fizz/dataframe";
 import { isUnplayable } from "../../../../audio/sonifier";
+import { NavNode } from "../navigation";
 
 export class GraphingCalculator extends LineChart {
   protected renderPts: number = 50;
@@ -117,9 +117,24 @@ export class GraphingCalculator extends LineChart {
     })
   }
 
-  protected _createDatapoints(): void {
-    super._createDatapoints();
-    if (this.paraview.store.settings.type.graph.visitedSeries > -1) {
+  init() {
+    // At this point, we're fully connected to the root of the view tree,
+    // so we can safely observe
+    this._observeStore();
+    this._layoutDatapoints();
+    this._createNavMap();
+    if (this.paraview.store.prevVisitedDatapoints.length == 1) {
+      for (let point of this.paraview.store.prevVisitedDatapoints) {
+        const xVal = point.datapointView.datapoint.facetValueAsNumber("x")!
+        const xPct = (xVal - this.axisInfo!.xLabelInfo.min!) / this.axisInfo!.xLabelInfo.range!
+        if (xPct < 0 || xPct > 1) {
+          continue
+        }
+        const datapointView = this.chartLandingView.datapointViews.sort((a, b) => Math.abs(a.datapoint.facetValueAsNumber("x")! - xVal) - Math.abs(b.datapoint.facetValueAsNumber("x")! - xVal))[0]
+        this.navToDatapoint(datapointView.seriesKey, datapointView.index)
+      }
+    }
+    else if (this.paraview.store.settings.type.graph.visitedSeries > -1) {
       const visited = this.chartLandingView.datapointViews.filter(v =>
         v.seriesKey == this.paraview.store.model!.seriesKeys[this.paraview.store.settings.type.graph.visitedSeries]
       ).map((datapointView) => ({  
@@ -161,6 +176,9 @@ export class GraphingCalculator extends LineChart {
       });
       this.addEquation(this.paraview.store.settings.type.graph.equation)
     }
+    else if (['axis.y.maxValue', 'axis.y.minValue'].includes(path)) {
+      this.clearStore()
+    }
     else if (['type.graph.resetAxes'].includes(path)) {
       const seriesFocused = this.isSeriesFocused();
       this.clearStore()
@@ -196,7 +214,7 @@ export class GraphingCalculator extends LineChart {
   }
 
   addEquation(eq: string) {
-    this._axisInfo = new AxisInfo(this.paraview.store, {
+    const axisInfo = new AxisInfo(this.paraview.store, {
       xValues: [this.paraview.store.settings.axis.x.minValue == "unset" ? -10 : this.paraview.store.settings.axis.x.minValue,
       this.paraview.store.settings.axis.x.maxValue == "unset" ? 10 : this.paraview.store.settings.axis.x.maxValue],
       yValues: [-10, 10],
@@ -224,8 +242,8 @@ export class GraphingCalculator extends LineChart {
       var xVals = [];
       var yVals = [];
       const points = this.settings.renderPts
-      const xMax = this.axisInfo!.xLabelInfo!.max ?? 10
-      const xMin = this.axisInfo!.xLabelInfo!.min ?? -10
+      const xMax = axisInfo!.xLabelInfo!.max ?? 10
+      const xMin = axisInfo!.xLabelInfo!.min ?? -10
       for (var i = 0; i < points; i++) {
         var tr = document.createElement("tr");
         var td1 = document.createElement("td");
@@ -354,6 +372,102 @@ export class GraphingCalculator extends LineChart {
         console.log("No sonifiable notes detected, ensure some portion of the graph is visible on screen")
       }
     }
+  }
+
+  protected _createPrimaryNavNodes() {
+    super._createPrimaryNavNodes();
+    // Create vertical links between datapoints
+    this._navMap!.root.query('series').forEach(seriesNode => {
+      seriesNode.allNodes('right')
+        .forEach((pointNode) => {
+          pointNode.connect('out', seriesNode!);
+        });
+    });
+  }
+
+  async move(dir: Direction) {
+    const cursor = this._navMap!.cursor!;
+    const link = cursor.getLink(dir)
+    if (dir === 'left' && cursor.type === 'datapoint' && cursor.datapointViews[0].index === 0) {
+      this.paraview.store.updateSettings(draft => {
+        draft.axis.x.minValue = this.axisInfo!.xLabelInfo.min! - 1;;
+      });
+      return
+    }
+
+    else if (dir === 'right' && cursor.type === 'datapoint'){
+      if (cursor.datapointViews[0].index
+        === this.paraview.store.model!.series[this.paraview.store.model?.seriesKeys.findIndex(s => s == cursor.datapointViews[0].seriesKey)!].length - 1) {
+        this.paraview.store.updateSettings(draft => {
+          draft.axis.x.maxValue = this.axisInfo!.xLabelInfo.max! + 1;
+        });
+        return
+      }
+    }
+    if (link instanceof NavNode && (link.type === "series" || link.type === "datapoint")) {
+      if ((dir === "left" || dir === "right") && link.datapointViews[0].datapoint.facetValueAsNumber("y")! > this.axisInfo!.yLabelInfo.max!) {
+        const yTier = Math.abs(Number(this.axisInfo?.yLabelInfo.labelTiers[0][0]) - Number(this.axisInfo?.yLabelInfo.labelTiers[0][1]))
+        const newYMax = Math.ceil(link.datapointViews[0].datapoint.facetValueAsNumber("y")! / yTier) * yTier;
+        this.paraview.store.updateSettings(draft => {
+          draft.axis.y.maxValue = newYMax
+        });
+        return
+      }
+      else if ((dir === "left" || dir === "right")  && link.datapointViews[0].datapoint.facetValueAsNumber("y")! < this.axisInfo!.yLabelInfo.min!) {
+        const yTier = Math.abs(Number(this.axisInfo?.yLabelInfo.labelTiers[0][0]) - Number(this.axisInfo?.yLabelInfo.labelTiers[0][1]))
+        const newYMin = Math.floor(link.datapointViews[0].datapoint.facetValueAsNumber("y")! / yTier) * yTier;
+        this.paraview.store.updateSettings(draft => {
+          draft.axis.y.minValue = newYMin;
+        });
+        return
+      }
+    }
+    await cursor.move(dir);
+  }
+
+  handlePan(startX: number, startY: number, endX: number, endY: number) {
+    const xRange = this.axisInfo!.xLabelInfo.range!
+    const yRange = this.axisInfo!.yLabelInfo.range!
+    const xTier = Math.abs(Number(this.axisInfo?.xLabelInfo.labelTiers[0][0]) - Number(this.axisInfo?.xLabelInfo.labelTiers[0][1]))
+    const yTier = Math.abs(Number(this.axisInfo?.yLabelInfo.labelTiers[0][0]) - Number(this.axisInfo?.yLabelInfo.labelTiers[0][1]))
+    const changeHorizRaw = (endX - startX) / this.width
+    const changeVertRaw = (endY - startY) / this.height
+    const changeHoriz = Math.round(changeHorizRaw * xRange / xTier) * xTier;
+    const changeVert = Math.round(changeVertRaw * yRange / yTier) * yTier;
+    if (changeHoriz !== 0 || changeVert !== 0) {
+      const seriesFocused = this.isSeriesFocused();
+      this.clearStore()
+      this.paraview.store.updateSettings(draft => {
+        draft.axis.x.maxValue = this.axisInfo!.xLabelInfo.max! - (changeHoriz);
+        draft.axis.x.minValue = this.axisInfo!.xLabelInfo.min! - (changeHoriz);
+        draft.axis.y.maxValue = this.axisInfo!.yLabelInfo.max! + (changeVert);
+        draft.axis.y.minValue = this.axisInfo!.yLabelInfo.min! + (changeVert);
+      });
+      this.paraview.store.updateSettings(draft => {
+        draft.type.graph.visitedSeries = seriesFocused;
+      });
+    }
+
+  }
+
+  handleZoom(x: number, y: number): void {
+    const xTier = Math.abs(Number(this.axisInfo?.xLabelInfo.labelTiers[0][0]) - Number(this.axisInfo?.xLabelInfo.labelTiers[0][1]))
+    const yTier = Math.abs(Number(this.axisInfo?.yLabelInfo.labelTiers[0][0]) - Number(this.axisInfo?.yLabelInfo.labelTiers[0][1]))
+    const xConverted = (x / this.width) * this.axisInfo!.xLabelInfo.range! + this.axisInfo!.xLabelInfo.min!
+    const yConverted = ((this.height - y) / this.height) * this.axisInfo!.yLabelInfo.range! + this.axisInfo!.yLabelInfo.min!
+    const xRounded = Math.round( xConverted / xTier) * xTier
+    const yRounded = Math.round( yConverted / yTier) * yTier
+    const seriesFocused = this.isSeriesFocused();
+    this.clearStore()
+    this.paraview.store.updateSettings(draft => {
+      draft.axis.x.maxValue = xRounded + xTier * 2
+      draft.axis.x.minValue = xRounded - xTier * 2
+      draft.axis.y.maxValue = yRounded + yTier * 2
+      draft.axis.y.minValue = yRounded - yTier * 2
+    });
+    this.paraview.store.updateSettings(draft => {
+      draft.type.graph.visitedSeries = seriesFocused;
+    });
   }
 }
 

--- a/lib/view/layers/data/data_layer.ts
+++ b/lib/view/layers/data/data_layer.ts
@@ -468,4 +468,8 @@ export abstract class DataLayer extends ChartLayer {
     }
     return null;
   }
+
+  handlePan(startX: number, startY: number, endX: number, endY: number){}
+
+  handleZoom(x: number, y: number){}
 }


### PR DESCRIPTION
https://github.com/fizzstudio/Future-Work/issues/49

-Adds intercepts in `PointerEventManger.handleEnd()` and `PointerEventManger.handleDoubleClick()` that direct to functions `Calculator.handlePan()` and `Calculator.handleZoom()` respectively.

-`clearSelected()` and `clearVisited()` now correctly transfer current array to prev array

-Keyboard navigating off the 'edge' of a graph horizontally or vertically will push the axes outwards while approximating the location of the cursor to the new axes.

-After `init()` is called, it will attempt to remember whether a single point or a series was visited before recreating the document view based on `prevVisitedDatapoints()` and a setting which stores whether a series is being focused on just before recreation.

-Each point in a graph now points 'out' to its series landing.