### PR TITLE
Fix exiting low-vision mode with `l`.

### DIFF
--- a/lib/paraview/hotkey_actions.ts
+++ b/lib/paraview/hotkey_actions.ts
@@ -150,7 +150,12 @@ export class HotkeyActions {
       },
       lowVisionModeToggle() {
         store.updateSettings(draft => {
-          draft.ui.isLowVisionModeEnabled = !draft.ui.isLowVisionModeEnabled;
+          if (draft.ui.isLowVisionModeEnabled) {
+            // Allow the exit from fullscreen to disable LV mode
+            draft.ui.isFullscreenEnabled = false;
+          } else {
+            draft.ui.isLowVisionModeEnabled = true;
+          }
         });
       },
       openHelp() {


### PR DESCRIPTION
Closes #574.