### PR TITLE
Separate autogenerated stories into `autogen` and `autogen-test` directories

### DIFF
--- a/.storybook-test/main.ts
+++ b/.storybook-test/main.ts
@@ -17,7 +17,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 import type { StorybookConfig } from "@storybook/web-components-vite";
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  stories: [
+    "../src/stories/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../src/stories/autogen-test/**/*.stories.@(js|jsx|mjs|ts|tsx)"
+  ],
 
   addons: [
     "@storybook/addon-links",

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -17,7 +17,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 import type { StorybookConfig } from "@storybook/web-components-vite";
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  stories: [
+    "../src/stories/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../src/stories/autogen/**/*.stories.@(js|jsx|mjs|ts|tsx)"
+  ],
 
   addons: [
     "@storybook/addon-links",

--- a/src/stories/autogen-test/AIbarMulti0.stories.ts
+++ b/src/stories/autogen-test/AIbarMulti0.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Bar Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart0: Story = {
+  name: "14: College enrollment in public and private institutions in the U.S. 1965 to 2028 (0)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-14.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-14.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIbarMulti1.stories.ts
+++ b/src/stories/autogen-test/AIbarMulti1.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Bar Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart1: Story = {
+  name: "149: Class 8 truck manufacturers - sales 2007 to 2018 (1)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-149.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-149.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIbarMulti2.stories.ts
+++ b/src/stories/autogen-test/AIbarMulti2.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Bar Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart2: Story = {
+  name: "15: Facebook: annual revenue and net income 2007 to 2019 (2)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-15.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-15.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIbarMulti3.stories.ts
+++ b/src/stories/autogen-test/AIbarMulti3.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Bar Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart3: Story = {
+  name: "178: Global construction machinery market size by region: outlook 2019 (3)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-178.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-178.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIbarMulti4.stories.ts
+++ b/src/stories/autogen-test/AIbarMulti4.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Bar Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart4: Story = {
+  name: "48: Gross domestic product of the ASEAN countries from 2008 to 2018 (4)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-48.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-48.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIbarMulti5.stories.ts
+++ b/src/stories/autogen-test/AIbarMulti5.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Bar Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart5: Story = {
+  name: "61: Age distribution in India 2008 to 2018 (5)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-61.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-61.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIbarSingle6.stories.ts
+++ b/src/stories/autogen-test/AIbarSingle6.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Single Bar Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart6: Story = {
+  name: "1018: Unemployment rate in Greece 1999-2019 (6)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-1018.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-1018.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIbarSingle7.stories.ts
+++ b/src/stories/autogen-test/AIbarSingle7.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Single Bar Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart7: Story = {
+  name: "13: Real GDP growth in the United States, by quarter 2011 to 2019 (7)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-13.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-13.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIbarSingle8.stories.ts
+++ b/src/stories/autogen-test/AIbarSingle8.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Single Bar Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart8: Story = {
+  name: "27: Spotify's premium subscribers 2015 to 2019 (8)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-27.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-27.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIcolumnMulti0.stories.ts
+++ b/src/stories/autogen-test/AIcolumnMulti0.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Column Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart0: Story = {
+  name: "14: College enrollment in public and private institutions in the U.S. 1965 to 2028 (0)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-14.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-14.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIcolumnMulti1.stories.ts
+++ b/src/stories/autogen-test/AIcolumnMulti1.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Column Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart1: Story = {
+  name: "149: Class 8 truck manufacturers - sales 2007 to 2018 (1)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-149.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-149.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIcolumnMulti2.stories.ts
+++ b/src/stories/autogen-test/AIcolumnMulti2.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Column Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart2: Story = {
+  name: "15: Facebook: annual revenue and net income 2007 to 2019 (2)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-15.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-15.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIcolumnMulti3.stories.ts
+++ b/src/stories/autogen-test/AIcolumnMulti3.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Column Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart3: Story = {
+  name: "178: Global construction machinery market size by region: outlook 2019 (3)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-178.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-178.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIcolumnMulti4.stories.ts
+++ b/src/stories/autogen-test/AIcolumnMulti4.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Column Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart4: Story = {
+  name: "48: Gross domestic product of the ASEAN countries from 2008 to 2018 (4)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-48.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-48.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIcolumnMulti5.stories.ts
+++ b/src/stories/autogen-test/AIcolumnMulti5.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Column Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart5: Story = {
+  name: "61: Age distribution in India 2008 to 2018 (5)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-61.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-61.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIcolumnSingle6.stories.ts
+++ b/src/stories/autogen-test/AIcolumnSingle6.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Single Column Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart6: Story = {
+  name: "1018: Unemployment rate in Greece 1999-2019 (6)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-1018.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-1018.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIcolumnSingle7.stories.ts
+++ b/src/stories/autogen-test/AIcolumnSingle7.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Single Column Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart7: Story = {
+  name: "13: Real GDP growth in the United States, by quarter 2011 to 2019 (7)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-13.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-13.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIcolumnSingle8.stories.ts
+++ b/src/stories/autogen-test/AIcolumnSingle8.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Single Column Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart8: Story = {
+  name: "27: Spotify's premium subscribers 2015 to 2019 (8)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-27.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-27.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIdonut47.stories.ts
+++ b/src/stories/autogen-test/AIdonut47.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/donutTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Pastry Charts/Donut Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart47: Story = {
+  name: "Division of energy in the Universe (47)",
+  args: {
+    filename: "manifests/pie-manifest-dark-matter.json",
+    forcecharttype: "donut",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/pie-manifest-dark-matter.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineMulti10.stories.ts
+++ b/src/stories/autogen-test/AIlineMulti10.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart10: Story = {
+  name: "16: Distribution of the workforce across economic sectors in India 2019 (10)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-16.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-16.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineMulti11.stories.ts
+++ b/src/stories/autogen-test/AIlineMulti11.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart11: Story = {
+  name: "175: Distribution of gross domestic product (GDP) across economic sectors Pakistan 2018 (11)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-175.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-175.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineMulti12.stories.ts
+++ b/src/stories/autogen-test/AIlineMulti12.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart12: Story = {
+  name: "233: Advertising spending in Vietnam 2004-2018, by medium (12)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-233.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-233.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineMulti13.stories.ts
+++ b/src/stories/autogen-test/AIlineMulti13.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart13: Story = {
+  name: "261: Passenger cars - sales in selected countries worldwide 2005 to 2018 (13)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-261.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-261.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineMulti14.stories.ts
+++ b/src/stories/autogen-test/AIlineMulti14.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart14: Story = {
+  name: "27: Adidas, Nike & Puma revenue comparison 2006 to 2018 (14)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-27.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-27.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineMulti15.stories.ts
+++ b/src/stories/autogen-test/AIlineMulti15.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart15: Story = {
+  name: "57: Distribution of GDP across economic sectors in China 2008 to 2018 (15)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-57.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-57.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineMulti16.stories.ts
+++ b/src/stories/autogen-test/AIlineMulti16.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart16: Story = {
+  name: "67: Gross domestic product of the BRIC countries from 2014 to 2024 (16)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-67.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-67.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineMulti17.stories.ts
+++ b/src/stories/autogen-test/AIlineMulti17.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart17: Story = {
+  name: "76: Inflation rate in EU and Euro area 2024 (17)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-76.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-76.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineMulti18.stories.ts
+++ b/src/stories/autogen-test/AIlineMulti18.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart18: Story = {
+  name: "Pokemon: Holographic Pokemon Card Price (18)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-Pokemon.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-Pokemon.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineMulti9.stories.ts
+++ b/src/stories/autogen-test/AIlineMulti9.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart9: Story = {
+  name: "128: Gross domestic product (GDP) growth in EU and Euro area 2024 (9)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-128.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-128.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle19.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle19.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart19: Story = {
+  name: "1047: Number of Xbox Live MAU Q1 2016 - Q4 2019 (19)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-1047.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1047.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle20.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle20.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart20: Story = {
+  name: "1066: Median age of the population in Vietnam 2015 (20)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-1066.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1066.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle21.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle21.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart21: Story = {
+  name: "1107: Unemployment rate in Spain 2005 to 2019 (21)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-1107.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1107.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle22.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle22.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart22: Story = {
+  name: "128: Cattle population worldwide 2012 to 2019 (22)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-128.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-128.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle23.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle23.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart23: Story = {
+  name: "172: Median household income in the United States 1990 to 2018 (23)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-172.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-172.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle24.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle24.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart24: Story = {
+  name: "328: General Motors - number of employees 2019 (24)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-328.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-328.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle25.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle25.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart25: Story = {
+  name: "375: Tesla's revenue 2008 to 2019 (25)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-375.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-375.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle26.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle26.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart26: Story = {
+  name: "489: Growth rate of the global cosmetics market 2004 to 2018 (26)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-489.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-489.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle27.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle27.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart27: Story = {
+  name: "508: Indonesia: number of internet users 2017 to 2023 (27)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-508.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-508.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle28.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle28.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart28: Story = {
+  name: "541: USA - number of arrests for all offenses 1990 to 2018 (28)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-541.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-541.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle29.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle29.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart29: Story = {
+  name: "595: Number of births in Canada 2000 to 2019 (29)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-595.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-595.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle30.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle30.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart30: Story = {
+  name: "605: Samsung Electronics' operating profit 2009-2019, by quarter (30)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-605.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-605.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle31.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle31.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart31: Story = {
+  name: "7: Estimated number of World of Warcraft subscribers 2015 to 2023 (31)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-7.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-7.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle32.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle32.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart32: Story = {
+  name: "746: Inflation rate in Sri Lanka 2024 (32)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-746.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-746.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle33.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle33.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart33: Story = {
+  name: "843: New York Yankees revenue 2001 to 2018 (33)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-843.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-843.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle34.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle34.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart34: Story = {
+  name: "881: FedEx's revenue 2009 to 2019 (34)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-881.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-881.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle35.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle35.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart35: Story = {
+  name: "887: Youth unemployment rate in India in 2019 (35)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-887.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-887.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle36.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle36.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart36: Story = {
+  name: "913: Number of commercial casinos in the U.S. 2005 to 2018 (36)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-913.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-913.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle37.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle37.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart37: Story = {
+  name: "930: Suicide rate in Japan 2009 to 2018 (37)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-930.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-930.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle38.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle38.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart38: Story = {
+  name: "937: Movie releases in North America from 2000 to 2019 (38)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-937.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-937.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle39.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle39.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart39: Story = {
+  name: "951: National debt of Ireland 2024 (39)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-951.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-951.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle40.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle40.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart40: Story = {
+  name: "965: Annual performance of the Dow Jones Composite Index 2000 to 2019 (40)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-965.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-965.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle41.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle41.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart41: Story = {
+  name: "979: Total number of gang-related homicides in the United States 2012 (41)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-979.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-979.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlineSingle42.stories.ts
+++ b/src/stories/autogen-test/AIlineSingle42.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart42: Story = {
+  name: "Charizard: Holographic Charizard Card Price (42)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-Charizard.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-Charizard.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlollipopMulti0.stories.ts
+++ b/src/stories/autogen-test/AIlollipopMulti0.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Lollipop Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart0: Story = {
+  name: "14: College enrollment in public and private institutions in the U.S. 1965 to 2028 (0)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-14.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-14.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlollipopMulti1.stories.ts
+++ b/src/stories/autogen-test/AIlollipopMulti1.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Lollipop Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart1: Story = {
+  name: "149: Class 8 truck manufacturers - sales 2007 to 2018 (1)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-149.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-149.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlollipopMulti2.stories.ts
+++ b/src/stories/autogen-test/AIlollipopMulti2.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Lollipop Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart2: Story = {
+  name: "15: Facebook: annual revenue and net income 2007 to 2019 (2)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-15.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-15.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlollipopMulti3.stories.ts
+++ b/src/stories/autogen-test/AIlollipopMulti3.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Lollipop Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart3: Story = {
+  name: "178: Global construction machinery market size by region: outlook 2019 (3)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-178.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-178.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlollipopMulti4.stories.ts
+++ b/src/stories/autogen-test/AIlollipopMulti4.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Lollipop Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart4: Story = {
+  name: "48: Gross domestic product of the ASEAN countries from 2008 to 2018 (4)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-48.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-48.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlollipopMulti5.stories.ts
+++ b/src/stories/autogen-test/AIlollipopMulti5.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Lollipop Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart5: Story = {
+  name: "61: Age distribution in India 2008 to 2018 (5)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-61.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-61.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlollipopSingle6.stories.ts
+++ b/src/stories/autogen-test/AIlollipopSingle6.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Single Lollipop Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart6: Story = {
+  name: "1018: Unemployment rate in Greece 1999-2019 (6)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-1018.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-1018.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlollipopSingle7.stories.ts
+++ b/src/stories/autogen-test/AIlollipopSingle7.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Single Lollipop Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart7: Story = {
+  name: "13: Real GDP growth in the United States, by quarter 2011 to 2019 (7)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-13.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-13.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIlollipopSingle8.stories.ts
+++ b/src/stories/autogen-test/AIlollipopSingle8.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Single Lollipop Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart8: Story = {
+  name: "27: Spotify's premium subscribers 2015 to 2019 (8)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-27.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-27.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIpie47.stories.ts
+++ b/src/stories/autogen-test/AIpie47.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/pieTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Pastry Charts/Pie Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart47: Story = {
+  name: "Division of energy in the Universe (47)",
+  args: {
+    filename: "manifests/pie-manifest-dark-matter.json",
+    forcecharttype: "pie",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/pie-manifest-dark-matter.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIscatter49.stories.ts
+++ b/src/stories/autogen-test/AIscatter49.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/scatterTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Scatter Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart49: Story = {
+  name: "d3 (49)",
+  args: {
+    filename: "manifests/scatter-manifest-d3.json",
+    forcecharttype: "scatter",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-d3.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIscatter51.stories.ts
+++ b/src/stories/autogen-test/AIscatter51.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/scatterTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Scatter Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart51: Story = {
+  name: "Old Faithful Geyser Eruptions (51)",
+  args: {
+    filename: "manifests/scatter-manifest-geyser.json",
+    forcecharttype: "scatter",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-geyser.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIscatter54.stories.ts
+++ b/src/stories/autogen-test/AIscatter54.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/scatterTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Scatter Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart54: Story = {
+  name: "Iris Flower Data Set (54)",
+  args: {
+    filename: "manifests/scatter-manifest-iris-petal.json",
+    forcecharttype: "scatter",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-iris-petal.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIscatter56.stories.ts
+++ b/src/stories/autogen-test/AIscatter56.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/scatterTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Scatter Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart56: Story = {
+  name: "s1 (56)",
+  args: {
+    filename: "manifests/scatter-manifest-s1.json",
+    forcecharttype: "scatter",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-s1.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIscatter58.stories.ts
+++ b/src/stories/autogen-test/AIscatter58.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/scatterTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Scatter Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart58: Story = {
+  name: "s2 (58)",
+  args: {
+    filename: "manifests/scatter-manifest-s2.json",
+    forcecharttype: "scatter",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-s2.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineMulti10.stories.ts
+++ b/src/stories/autogen-test/AIsteplineMulti10.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart10: Story = {
+  name: "16: Distribution of the workforce across economic sectors in India 2019 (10)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-16.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-16.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineMulti11.stories.ts
+++ b/src/stories/autogen-test/AIsteplineMulti11.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart11: Story = {
+  name: "175: Distribution of gross domestic product (GDP) across economic sectors Pakistan 2018 (11)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-175.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-175.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineMulti12.stories.ts
+++ b/src/stories/autogen-test/AIsteplineMulti12.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart12: Story = {
+  name: "233: Advertising spending in Vietnam 2004-2018, by medium (12)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-233.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-233.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineMulti13.stories.ts
+++ b/src/stories/autogen-test/AIsteplineMulti13.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart13: Story = {
+  name: "261: Passenger cars - sales in selected countries worldwide 2005 to 2018 (13)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-261.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-261.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineMulti14.stories.ts
+++ b/src/stories/autogen-test/AIsteplineMulti14.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart14: Story = {
+  name: "27: Adidas, Nike & Puma revenue comparison 2006 to 2018 (14)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-27.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-27.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineMulti15.stories.ts
+++ b/src/stories/autogen-test/AIsteplineMulti15.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart15: Story = {
+  name: "57: Distribution of GDP across economic sectors in China 2008 to 2018 (15)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-57.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-57.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineMulti16.stories.ts
+++ b/src/stories/autogen-test/AIsteplineMulti16.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart16: Story = {
+  name: "67: Gross domestic product of the BRIC countries from 2014 to 2024 (16)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-67.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-67.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineMulti17.stories.ts
+++ b/src/stories/autogen-test/AIsteplineMulti17.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart17: Story = {
+  name: "76: Inflation rate in EU and Euro area 2024 (17)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-76.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-76.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineMulti18.stories.ts
+++ b/src/stories/autogen-test/AIsteplineMulti18.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart18: Story = {
+  name: "Pokemon: Holographic Pokemon Card Price (18)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-Pokemon.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-Pokemon.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineMulti9.stories.ts
+++ b/src/stories/autogen-test/AIsteplineMulti9.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart9: Story = {
+  name: "128: Gross domestic product (GDP) growth in EU and Euro area 2024 (9)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-128.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-128.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle19.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle19.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart19: Story = {
+  name: "1047: Number of Xbox Live MAU Q1 2016 - Q4 2019 (19)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-1047.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1047.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle20.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle20.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart20: Story = {
+  name: "1066: Median age of the population in Vietnam 2015 (20)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-1066.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1066.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle21.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle21.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart21: Story = {
+  name: "1107: Unemployment rate in Spain 2005 to 2019 (21)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-1107.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1107.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle22.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle22.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart22: Story = {
+  name: "128: Cattle population worldwide 2012 to 2019 (22)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-128.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-128.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle23.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle23.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart23: Story = {
+  name: "172: Median household income in the United States 1990 to 2018 (23)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-172.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-172.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle24.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle24.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart24: Story = {
+  name: "328: General Motors - number of employees 2019 (24)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-328.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-328.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle25.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle25.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart25: Story = {
+  name: "375: Tesla's revenue 2008 to 2019 (25)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-375.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-375.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle26.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle26.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart26: Story = {
+  name: "489: Growth rate of the global cosmetics market 2004 to 2018 (26)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-489.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-489.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle27.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle27.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart27: Story = {
+  name: "508: Indonesia: number of internet users 2017 to 2023 (27)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-508.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-508.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle28.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle28.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart28: Story = {
+  name: "541: USA - number of arrests for all offenses 1990 to 2018 (28)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-541.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-541.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle29.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle29.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart29: Story = {
+  name: "595: Number of births in Canada 2000 to 2019 (29)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-595.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-595.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle30.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle30.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart30: Story = {
+  name: "605: Samsung Electronics' operating profit 2009-2019, by quarter (30)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-605.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-605.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle31.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle31.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart31: Story = {
+  name: "7: Estimated number of World of Warcraft subscribers 2015 to 2023 (31)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-7.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-7.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle32.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle32.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart32: Story = {
+  name: "746: Inflation rate in Sri Lanka 2024 (32)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-746.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-746.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle33.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle33.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart33: Story = {
+  name: "843: New York Yankees revenue 2001 to 2018 (33)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-843.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-843.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle34.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle34.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart34: Story = {
+  name: "881: FedEx's revenue 2009 to 2019 (34)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-881.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-881.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle35.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle35.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart35: Story = {
+  name: "887: Youth unemployment rate in India in 2019 (35)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-887.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-887.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle36.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle36.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart36: Story = {
+  name: "913: Number of commercial casinos in the U.S. 2005 to 2018 (36)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-913.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-913.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle37.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle37.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart37: Story = {
+  name: "930: Suicide rate in Japan 2009 to 2018 (37)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-930.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-930.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle38.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle38.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart38: Story = {
+  name: "937: Movie releases in North America from 2000 to 2019 (38)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-937.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-937.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle39.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle39.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart39: Story = {
+  name: "951: National debt of Ireland 2024 (39)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-951.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-951.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle40.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle40.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart40: Story = {
+  name: "965: Annual performance of the Dow Jones Composite Index 2000 to 2019 (40)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-965.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-965.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle41.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle41.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart41: Story = {
+  name: "979: Total number of gang-related homicides in the United States 2012 (41)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-979.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-979.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/AIsteplineSingle42.stories.ts
+++ b/src/stories/autogen-test/AIsteplineSingle42.stories.ts
@@ -1,0 +1,27 @@
+import { AiChart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AiChart42: Story = {
+  name: "Charizard: Holographic Charizard Card Price (42)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-Charizard.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-Charizard.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/barMulti0.stories.ts
+++ b/src/stories/autogen-test/barMulti0.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Bar Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart0: Story = {
+  name: "14: College enrollment in public and private institutions in the U.S. 1965 to 2028 (0)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-14.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-14.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/barMulti1.stories.ts
+++ b/src/stories/autogen-test/barMulti1.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Bar Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart1: Story = {
+  name: "149: Class 8 truck manufacturers - sales 2007 to 2018 (1)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-149.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-149.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/barMulti2.stories.ts
+++ b/src/stories/autogen-test/barMulti2.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Bar Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart2: Story = {
+  name: "15: Facebook: annual revenue and net income 2007 to 2019 (2)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-15.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-15.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/barMulti3.stories.ts
+++ b/src/stories/autogen-test/barMulti3.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Bar Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart3: Story = {
+  name: "178: Global construction machinery market size by region: outlook 2019 (3)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-178.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-178.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/barMulti4.stories.ts
+++ b/src/stories/autogen-test/barMulti4.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Bar Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart4: Story = {
+  name: "48: Gross domestic product of the ASEAN countries from 2008 to 2018 (4)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-48.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-48.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/barMulti5.stories.ts
+++ b/src/stories/autogen-test/barMulti5.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Bar Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart5: Story = {
+  name: "61: Age distribution in India 2008 to 2018 (5)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-61.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-61.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/barSingle6.stories.ts
+++ b/src/stories/autogen-test/barSingle6.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Single Bar Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart6: Story = {
+  name: "1018: Unemployment rate in Greece 1999-2019 (6)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-1018.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-1018.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/barSingle7.stories.ts
+++ b/src/stories/autogen-test/barSingle7.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Single Bar Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart7: Story = {
+  name: "13: Real GDP growth in the United States, by quarter 2011 to 2019 (7)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-13.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-13.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/barSingle8.stories.ts
+++ b/src/stories/autogen-test/barSingle8.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/barTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Single Bar Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart8: Story = {
+  name: "27: Spotify's premium subscribers 2015 to 2019 (8)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-27.json",
+    forcecharttype: "bar",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-27.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/columnMulti0.stories.ts
+++ b/src/stories/autogen-test/columnMulti0.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Column Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart0: Story = {
+  name: "14: College enrollment in public and private institutions in the U.S. 1965 to 2028 (0)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-14.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-14.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/columnMulti1.stories.ts
+++ b/src/stories/autogen-test/columnMulti1.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Column Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart1: Story = {
+  name: "149: Class 8 truck manufacturers - sales 2007 to 2018 (1)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-149.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-149.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/columnMulti2.stories.ts
+++ b/src/stories/autogen-test/columnMulti2.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Column Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart2: Story = {
+  name: "15: Facebook: annual revenue and net income 2007 to 2019 (2)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-15.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-15.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/columnMulti3.stories.ts
+++ b/src/stories/autogen-test/columnMulti3.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Column Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart3: Story = {
+  name: "178: Global construction machinery market size by region: outlook 2019 (3)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-178.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-178.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/columnMulti4.stories.ts
+++ b/src/stories/autogen-test/columnMulti4.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Column Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart4: Story = {
+  name: "48: Gross domestic product of the ASEAN countries from 2008 to 2018 (4)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-48.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-48.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/columnMulti5.stories.ts
+++ b/src/stories/autogen-test/columnMulti5.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Column Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart5: Story = {
+  name: "61: Age distribution in India 2008 to 2018 (5)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-61.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-61.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/columnSingle6.stories.ts
+++ b/src/stories/autogen-test/columnSingle6.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Single Column Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart6: Story = {
+  name: "1018: Unemployment rate in Greece 1999-2019 (6)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-1018.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-1018.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/columnSingle7.stories.ts
+++ b/src/stories/autogen-test/columnSingle7.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Single Column Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart7: Story = {
+  name: "13: Real GDP growth in the United States, by quarter 2011 to 2019 (7)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-13.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-13.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/columnSingle8.stories.ts
+++ b/src/stories/autogen-test/columnSingle8.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/columnTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Single Column Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart8: Story = {
+  name: "27: Spotify's premium subscribers 2015 to 2019 (8)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-27.json",
+    forcecharttype: "column",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-27.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/donut47.stories.ts
+++ b/src/stories/autogen-test/donut47.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/donutTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Pastry Charts/Donut Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart47: Story = {
+  name: "Division of energy in the Universe (47)",
+  args: {
+    filename: "manifests/pie-manifest-dark-matter.json",
+    forcecharttype: "donut",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/pie-manifest-dark-matter.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineMulti10.stories.ts
+++ b/src/stories/autogen-test/lineMulti10.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart10: Story = {
+  name: "16: Distribution of the workforce across economic sectors in India 2019 (10)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-16.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-16.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineMulti11.stories.ts
+++ b/src/stories/autogen-test/lineMulti11.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart11: Story = {
+  name: "175: Distribution of gross domestic product (GDP) across economic sectors Pakistan 2018 (11)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-175.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-175.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineMulti12.stories.ts
+++ b/src/stories/autogen-test/lineMulti12.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart12: Story = {
+  name: "233: Advertising spending in Vietnam 2004-2018, by medium (12)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-233.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-233.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineMulti13.stories.ts
+++ b/src/stories/autogen-test/lineMulti13.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart13: Story = {
+  name: "261: Passenger cars - sales in selected countries worldwide 2005 to 2018 (13)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-261.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-261.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineMulti14.stories.ts
+++ b/src/stories/autogen-test/lineMulti14.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart14: Story = {
+  name: "27: Adidas, Nike & Puma revenue comparison 2006 to 2018 (14)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-27.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-27.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineMulti15.stories.ts
+++ b/src/stories/autogen-test/lineMulti15.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart15: Story = {
+  name: "57: Distribution of GDP across economic sectors in China 2008 to 2018 (15)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-57.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-57.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineMulti16.stories.ts
+++ b/src/stories/autogen-test/lineMulti16.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart16: Story = {
+  name: "67: Gross domestic product of the BRIC countries from 2014 to 2024 (16)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-67.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-67.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineMulti17.stories.ts
+++ b/src/stories/autogen-test/lineMulti17.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart17: Story = {
+  name: "76: Inflation rate in EU and Euro area 2024 (17)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-76.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-76.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineMulti18.stories.ts
+++ b/src/stories/autogen-test/lineMulti18.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart18: Story = {
+  name: "Pokemon: Holographic Pokemon Card Price (18)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-Pokemon.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-Pokemon.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineMulti9.stories.ts
+++ b/src/stories/autogen-test/lineMulti9.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart9: Story = {
+  name: "128: Gross domestic product (GDP) growth in EU and Euro area 2024 (9)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-128.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-128.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle19.stories.ts
+++ b/src/stories/autogen-test/lineSingle19.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart19: Story = {
+  name: "1047: Number of Xbox Live MAU Q1 2016 - Q4 2019 (19)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-1047.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1047.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle20.stories.ts
+++ b/src/stories/autogen-test/lineSingle20.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart20: Story = {
+  name: "1066: Median age of the population in Vietnam 2015 (20)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-1066.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1066.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle21.stories.ts
+++ b/src/stories/autogen-test/lineSingle21.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart21: Story = {
+  name: "1107: Unemployment rate in Spain 2005 to 2019 (21)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-1107.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1107.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle22.stories.ts
+++ b/src/stories/autogen-test/lineSingle22.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart22: Story = {
+  name: "128: Cattle population worldwide 2012 to 2019 (22)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-128.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-128.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle23.stories.ts
+++ b/src/stories/autogen-test/lineSingle23.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart23: Story = {
+  name: "172: Median household income in the United States 1990 to 2018 (23)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-172.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-172.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle24.stories.ts
+++ b/src/stories/autogen-test/lineSingle24.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart24: Story = {
+  name: "328: General Motors - number of employees 2019 (24)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-328.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-328.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle25.stories.ts
+++ b/src/stories/autogen-test/lineSingle25.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart25: Story = {
+  name: "375: Tesla's revenue 2008 to 2019 (25)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-375.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-375.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle26.stories.ts
+++ b/src/stories/autogen-test/lineSingle26.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart26: Story = {
+  name: "489: Growth rate of the global cosmetics market 2004 to 2018 (26)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-489.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-489.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle27.stories.ts
+++ b/src/stories/autogen-test/lineSingle27.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart27: Story = {
+  name: "508: Indonesia: number of internet users 2017 to 2023 (27)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-508.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-508.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle28.stories.ts
+++ b/src/stories/autogen-test/lineSingle28.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart28: Story = {
+  name: "541: USA - number of arrests for all offenses 1990 to 2018 (28)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-541.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-541.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle29.stories.ts
+++ b/src/stories/autogen-test/lineSingle29.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart29: Story = {
+  name: "595: Number of births in Canada 2000 to 2019 (29)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-595.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-595.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle30.stories.ts
+++ b/src/stories/autogen-test/lineSingle30.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart30: Story = {
+  name: "605: Samsung Electronics' operating profit 2009-2019, by quarter (30)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-605.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-605.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle31.stories.ts
+++ b/src/stories/autogen-test/lineSingle31.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart31: Story = {
+  name: "7: Estimated number of World of Warcraft subscribers 2015 to 2023 (31)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-7.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-7.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle32.stories.ts
+++ b/src/stories/autogen-test/lineSingle32.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart32: Story = {
+  name: "746: Inflation rate in Sri Lanka 2024 (32)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-746.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-746.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle33.stories.ts
+++ b/src/stories/autogen-test/lineSingle33.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart33: Story = {
+  name: "843: New York Yankees revenue 2001 to 2018 (33)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-843.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-843.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle34.stories.ts
+++ b/src/stories/autogen-test/lineSingle34.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart34: Story = {
+  name: "881: FedEx's revenue 2009 to 2019 (34)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-881.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-881.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle35.stories.ts
+++ b/src/stories/autogen-test/lineSingle35.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart35: Story = {
+  name: "887: Youth unemployment rate in India in 2019 (35)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-887.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-887.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle36.stories.ts
+++ b/src/stories/autogen-test/lineSingle36.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart36: Story = {
+  name: "913: Number of commercial casinos in the U.S. 2005 to 2018 (36)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-913.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-913.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle37.stories.ts
+++ b/src/stories/autogen-test/lineSingle37.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart37: Story = {
+  name: "930: Suicide rate in Japan 2009 to 2018 (37)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-930.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-930.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle38.stories.ts
+++ b/src/stories/autogen-test/lineSingle38.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart38: Story = {
+  name: "937: Movie releases in North America from 2000 to 2019 (38)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-937.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-937.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle39.stories.ts
+++ b/src/stories/autogen-test/lineSingle39.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart39: Story = {
+  name: "951: National debt of Ireland 2024 (39)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-951.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-951.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle40.stories.ts
+++ b/src/stories/autogen-test/lineSingle40.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart40: Story = {
+  name: "965: Annual performance of the Dow Jones Composite Index 2000 to 2019 (40)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-965.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-965.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle41.stories.ts
+++ b/src/stories/autogen-test/lineSingle41.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart41: Story = {
+  name: "979: Total number of gang-related homicides in the United States 2012 (41)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-979.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-979.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lineSingle42.stories.ts
+++ b/src/stories/autogen-test/lineSingle42.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart42: Story = {
+  name: "Charizard: Holographic Charizard Card Price (42)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-Charizard.json",
+    forcecharttype: "line",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-Charizard.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lollipopMulti0.stories.ts
+++ b/src/stories/autogen-test/lollipopMulti0.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Lollipop Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart0: Story = {
+  name: "14: College enrollment in public and private institutions in the U.S. 1965 to 2028 (0)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-14.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-14.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lollipopMulti1.stories.ts
+++ b/src/stories/autogen-test/lollipopMulti1.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Lollipop Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart1: Story = {
+  name: "149: Class 8 truck manufacturers - sales 2007 to 2018 (1)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-149.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-149.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lollipopMulti2.stories.ts
+++ b/src/stories/autogen-test/lollipopMulti2.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Lollipop Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart2: Story = {
+  name: "15: Facebook: annual revenue and net income 2007 to 2019 (2)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-15.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-15.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lollipopMulti3.stories.ts
+++ b/src/stories/autogen-test/lollipopMulti3.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Lollipop Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart3: Story = {
+  name: "178: Global construction machinery market size by region: outlook 2019 (3)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-178.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-178.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lollipopMulti4.stories.ts
+++ b/src/stories/autogen-test/lollipopMulti4.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Lollipop Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart4: Story = {
+  name: "48: Gross domestic product of the ASEAN countries from 2008 to 2018 (4)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-48.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-48.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lollipopMulti5.stories.ts
+++ b/src/stories/autogen-test/lollipopMulti5.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Lollipop Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart5: Story = {
+  name: "61: Age distribution in India 2008 to 2018 (5)",
+  args: {
+    filename: "manifests/autogen/bar-multi/bar-multi-manifest-61.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-61.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lollipopSingle6.stories.ts
+++ b/src/stories/autogen-test/lollipopSingle6.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Single Lollipop Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart6: Story = {
+  name: "1018: Unemployment rate in Greece 1999-2019 (6)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-1018.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-1018.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lollipopSingle7.stories.ts
+++ b/src/stories/autogen-test/lollipopSingle7.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Single Lollipop Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart7: Story = {
+  name: "13: Real GDP growth in the United States, by quarter 2011 to 2019 (7)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-13.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-13.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/lollipopSingle8.stories.ts
+++ b/src/stories/autogen-test/lollipopSingle8.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/lollipopTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Single Lollipop Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart8: Story = {
+  name: "27: Spotify's premium subscribers 2015 to 2019 (8)",
+  args: {
+    filename: "manifests/autogen/bar-single/bar-single-manifest-27.json",
+    forcecharttype: "lollipop",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-27.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/pie47.stories.ts
+++ b/src/stories/autogen-test/pie47.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/pieTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Pastry Charts/Pie Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart47: Story = {
+  name: "Division of energy in the Universe (47)",
+  args: {
+    filename: "manifests/pie-manifest-dark-matter.json",
+    forcecharttype: "pie",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/pie-manifest-dark-matter.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/scatter49.stories.ts
+++ b/src/stories/autogen-test/scatter49.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/scatterTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Scatter Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart49: Story = {
+  name: "d3 (49)",
+  args: {
+    filename: "manifests/scatter-manifest-d3.json",
+    forcecharttype: "scatter",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-d3.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/scatter51.stories.ts
+++ b/src/stories/autogen-test/scatter51.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/scatterTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Scatter Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart51: Story = {
+  name: "Old Faithful Geyser Eruptions (51)",
+  args: {
+    filename: "manifests/scatter-manifest-geyser.json",
+    forcecharttype: "scatter",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-geyser.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/scatter54.stories.ts
+++ b/src/stories/autogen-test/scatter54.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/scatterTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Scatter Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart54: Story = {
+  name: "Iris Flower Data Set (54)",
+  args: {
+    filename: "manifests/scatter-manifest-iris-petal.json",
+    forcecharttype: "scatter",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-iris-petal.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/scatter56.stories.ts
+++ b/src/stories/autogen-test/scatter56.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/scatterTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Scatter Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart56: Story = {
+  name: "s1 (56)",
+  args: {
+    filename: "manifests/scatter-manifest-s1.json",
+    forcecharttype: "scatter",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-s1.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/scatter58.stories.ts
+++ b/src/stories/autogen-test/scatter58.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/scatterTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Scatter Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart58: Story = {
+  name: "s2 (58)",
+  args: {
+    filename: "manifests/scatter-manifest-s2.json",
+    forcecharttype: "scatter",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-s2.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineMulti10.stories.ts
+++ b/src/stories/autogen-test/steplineMulti10.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart10: Story = {
+  name: "16: Distribution of the workforce across economic sectors in India 2019 (10)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-16.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-16.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineMulti11.stories.ts
+++ b/src/stories/autogen-test/steplineMulti11.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart11: Story = {
+  name: "175: Distribution of gross domestic product (GDP) across economic sectors Pakistan 2018 (11)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-175.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-175.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineMulti12.stories.ts
+++ b/src/stories/autogen-test/steplineMulti12.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart12: Story = {
+  name: "233: Advertising spending in Vietnam 2004-2018, by medium (12)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-233.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-233.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineMulti13.stories.ts
+++ b/src/stories/autogen-test/steplineMulti13.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart13: Story = {
+  name: "261: Passenger cars - sales in selected countries worldwide 2005 to 2018 (13)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-261.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-261.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineMulti14.stories.ts
+++ b/src/stories/autogen-test/steplineMulti14.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart14: Story = {
+  name: "27: Adidas, Nike & Puma revenue comparison 2006 to 2018 (14)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-27.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-27.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineMulti15.stories.ts
+++ b/src/stories/autogen-test/steplineMulti15.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart15: Story = {
+  name: "57: Distribution of GDP across economic sectors in China 2008 to 2018 (15)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-57.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-57.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineMulti16.stories.ts
+++ b/src/stories/autogen-test/steplineMulti16.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart16: Story = {
+  name: "67: Gross domestic product of the BRIC countries from 2014 to 2024 (16)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-67.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-67.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineMulti17.stories.ts
+++ b/src/stories/autogen-test/steplineMulti17.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart17: Story = {
+  name: "76: Inflation rate in EU and Euro area 2024 (17)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-76.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-76.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineMulti18.stories.ts
+++ b/src/stories/autogen-test/steplineMulti18.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart18: Story = {
+  name: "Pokemon: Holographic Pokemon Card Price (18)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-Pokemon.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-Pokemon.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineMulti9.stories.ts
+++ b/src/stories/autogen-test/steplineMulti9.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart9: Story = {
+  name: "128: Gross domestic product (GDP) growth in EU and Euro area 2024 (9)",
+  args: {
+    filename: "manifests/autogen/line-multi/line-multi-manifest-128.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-128.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle19.stories.ts
+++ b/src/stories/autogen-test/steplineSingle19.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart19: Story = {
+  name: "1047: Number of Xbox Live MAU Q1 2016 - Q4 2019 (19)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-1047.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1047.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle20.stories.ts
+++ b/src/stories/autogen-test/steplineSingle20.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart20: Story = {
+  name: "1066: Median age of the population in Vietnam 2015 (20)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-1066.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1066.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle21.stories.ts
+++ b/src/stories/autogen-test/steplineSingle21.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart21: Story = {
+  name: "1107: Unemployment rate in Spain 2005 to 2019 (21)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-1107.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1107.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle22.stories.ts
+++ b/src/stories/autogen-test/steplineSingle22.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart22: Story = {
+  name: "128: Cattle population worldwide 2012 to 2019 (22)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-128.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-128.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle23.stories.ts
+++ b/src/stories/autogen-test/steplineSingle23.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart23: Story = {
+  name: "172: Median household income in the United States 1990 to 2018 (23)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-172.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-172.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle24.stories.ts
+++ b/src/stories/autogen-test/steplineSingle24.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart24: Story = {
+  name: "328: General Motors - number of employees 2019 (24)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-328.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-328.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle25.stories.ts
+++ b/src/stories/autogen-test/steplineSingle25.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart25: Story = {
+  name: "375: Tesla's revenue 2008 to 2019 (25)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-375.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-375.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle26.stories.ts
+++ b/src/stories/autogen-test/steplineSingle26.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart26: Story = {
+  name: "489: Growth rate of the global cosmetics market 2004 to 2018 (26)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-489.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-489.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle27.stories.ts
+++ b/src/stories/autogen-test/steplineSingle27.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart27: Story = {
+  name: "508: Indonesia: number of internet users 2017 to 2023 (27)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-508.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-508.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle28.stories.ts
+++ b/src/stories/autogen-test/steplineSingle28.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart28: Story = {
+  name: "541: USA - number of arrests for all offenses 1990 to 2018 (28)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-541.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-541.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle29.stories.ts
+++ b/src/stories/autogen-test/steplineSingle29.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart29: Story = {
+  name: "595: Number of births in Canada 2000 to 2019 (29)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-595.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-595.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle30.stories.ts
+++ b/src/stories/autogen-test/steplineSingle30.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart30: Story = {
+  name: "605: Samsung Electronics' operating profit 2009-2019, by quarter (30)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-605.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-605.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle31.stories.ts
+++ b/src/stories/autogen-test/steplineSingle31.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart31: Story = {
+  name: "7: Estimated number of World of Warcraft subscribers 2015 to 2023 (31)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-7.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-7.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle32.stories.ts
+++ b/src/stories/autogen-test/steplineSingle32.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart32: Story = {
+  name: "746: Inflation rate in Sri Lanka 2024 (32)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-746.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-746.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle33.stories.ts
+++ b/src/stories/autogen-test/steplineSingle33.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart33: Story = {
+  name: "843: New York Yankees revenue 2001 to 2018 (33)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-843.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-843.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle34.stories.ts
+++ b/src/stories/autogen-test/steplineSingle34.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart34: Story = {
+  name: "881: FedEx's revenue 2009 to 2019 (34)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-881.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-881.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle35.stories.ts
+++ b/src/stories/autogen-test/steplineSingle35.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart35: Story = {
+  name: "887: Youth unemployment rate in India in 2019 (35)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-887.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-887.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle36.stories.ts
+++ b/src/stories/autogen-test/steplineSingle36.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart36: Story = {
+  name: "913: Number of commercial casinos in the U.S. 2005 to 2018 (36)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-913.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-913.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle37.stories.ts
+++ b/src/stories/autogen-test/steplineSingle37.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart37: Story = {
+  name: "930: Suicide rate in Japan 2009 to 2018 (37)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-930.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-930.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle38.stories.ts
+++ b/src/stories/autogen-test/steplineSingle38.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart38: Story = {
+  name: "937: Movie releases in North America from 2000 to 2019 (38)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-937.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-937.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle39.stories.ts
+++ b/src/stories/autogen-test/steplineSingle39.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart39: Story = {
+  name: "951: National debt of Ireland 2024 (39)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-951.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-951.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle40.stories.ts
+++ b/src/stories/autogen-test/steplineSingle40.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart40: Story = {
+  name: "965: Annual performance of the Dow Jones Composite Index 2000 to 2019 (40)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-965.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-965.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle41.stories.ts
+++ b/src/stories/autogen-test/steplineSingle41.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart41: Story = {
+  name: "979: Total number of gang-related homicides in the United States 2012 (41)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-979.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-979.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/steplineSingle42.stories.ts
+++ b/src/stories/autogen-test/steplineSingle42.stories.ts
@@ -1,0 +1,27 @@
+import { Chart, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/steplineTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const Chart42: Story = {
+  name: "Charizard: Holographic Charizard Card Price (42)",
+  args: {
+    filename: "manifests/autogen/line-single/line-single-manifest-Charizard.json",
+    forcecharttype: "stepline",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-Charizard.json");
+    await runner.run();
+  }
+}

--- a/src/stories/autogen-test/zAIalldonut.stories.ts
+++ b/src/stories/autogen-test/zAIalldonut.stories.ts
@@ -1,0 +1,30 @@
+import { AiChart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('pastry', false);
+
+const meta = {
+  title: "AI-enhanced Charts/Pastry Charts/Donut Charts",
+  render: (args) => AiChart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllAIDonutCharts: Story = {
+  name: 'All Donut Charts',
+  args: {
+    filename: '',
+    forcecharttype: "donut",
+  }
+};

--- a/src/stories/autogen-test/zAIallhistogram.stories.ts
+++ b/src/stories/autogen-test/zAIallhistogram.stories.ts
@@ -1,0 +1,30 @@
+import { AiChart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('histogram', false);
+
+const meta = {
+  title: "AI-enhanced Charts/Histograms",
+  render: (args) => AiChart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllAIHistogramCharts: Story = {
+  name: 'All Histogram Charts',
+  args: {
+    filename: '',
+    forcecharttype: "histogram",
+  }
+};

--- a/src/stories/autogen-test/zAIallmultibar.stories.ts
+++ b/src/stories/autogen-test/zAIallmultibar.stories.ts
@@ -1,0 +1,30 @@
+import { AiChart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('bar', true);
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Bar Charts",
+  render: (args) => AiChart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllMultiBarCharts: Story = {
+  name: 'All Multi Bar Charts',
+  args: {
+    filename: '',
+    forcecharttype: "bar",
+  }
+};

--- a/src/stories/autogen-test/zAIallmulticolumn.stories.ts
+++ b/src/stories/autogen-test/zAIallmulticolumn.stories.ts
@@ -1,0 +1,30 @@
+import { AiChart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('bar', true);
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Column Charts",
+  render: (args) => AiChart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllMultiColumnCharts: Story = {
+  name: 'All Multi Column Charts',
+  args: {
+    filename: '',
+    forcecharttype: "column",
+  }
+};

--- a/src/stories/autogen-test/zAIallmultiline.stories.ts
+++ b/src/stories/autogen-test/zAIallmultiline.stories.ts
@@ -1,0 +1,30 @@
+import { AiChart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('line', true);
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Line Charts",
+  render: (args) => AiChart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllMultiLineCharts: Story = {
+  name: 'All Multi Line Charts',
+  args: {
+    filename: '',
+    forcecharttype: "line",
+  }
+};

--- a/src/stories/autogen-test/zAIallmultilollipop.stories.ts
+++ b/src/stories/autogen-test/zAIallmultilollipop.stories.ts
@@ -1,0 +1,30 @@
+import { AiChart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('bar', true);
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Multi Lollipop Charts",
+  render: (args) => AiChart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllMultiLollipopCharts: Story = {
+  name: 'All Multi Lollipop Charts',
+  args: {
+    filename: '',
+    forcecharttype: "lollipop",
+  }
+};

--- a/src/stories/autogen-test/zAIallmultistepline.stories.ts
+++ b/src/stories/autogen-test/zAIallmultistepline.stories.ts
@@ -1,0 +1,30 @@
+import { AiChart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('line', true);
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => AiChart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllMultiSteplineCharts: Story = {
+  name: 'All Multi Stepline Charts',
+  args: {
+    filename: '',
+    forcecharttype: "stepline",
+  }
+};

--- a/src/stories/autogen-test/zAIallpie.stories.ts
+++ b/src/stories/autogen-test/zAIallpie.stories.ts
@@ -1,0 +1,30 @@
+import { AiChart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('pastry', false);
+
+const meta = {
+  title: "AI-enhanced Charts/Pastry Charts/Pie Charts",
+  render: (args) => AiChart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllAIPieCharts: Story = {
+  name: 'All Pie Charts',
+  args: {
+    filename: '',
+    forcecharttype: "pie",
+  }
+};

--- a/src/stories/autogen-test/zAIallscatter.stories.ts
+++ b/src/stories/autogen-test/zAIallscatter.stories.ts
@@ -1,0 +1,30 @@
+import { AiChart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('scatter', false);
+
+const meta = {
+  title: "AI-enhanced Charts/Scatter Charts",
+  render: (args) => AiChart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllAIScatterCharts: Story = {
+  name: 'All Scatter Charts',
+  args: {
+    filename: '',
+    forcecharttype: "scatter",
+  }
+};

--- a/src/stories/autogen-test/zAIallsinglebar.stories.ts
+++ b/src/stories/autogen-test/zAIallsinglebar.stories.ts
@@ -1,0 +1,30 @@
+import { AiChart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('bar', true);
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Single Bar Charts",
+  render: (args) => AiChart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllSingleBarCharts: Story = {
+  name: 'All Single Bar Charts',
+  args: {
+    filename: '',
+    forcecharttype: "bar",
+  }
+};

--- a/src/stories/autogen-test/zAIallsinglecolumn.stories.ts
+++ b/src/stories/autogen-test/zAIallsinglecolumn.stories.ts
@@ -1,0 +1,30 @@
+import { AiChart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('bar', true);
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Single Column Charts",
+  render: (args) => AiChart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllSingleColumnCharts: Story = {
+  name: 'All Single Column Charts',
+  args: {
+    filename: '',
+    forcecharttype: "column",
+  }
+};

--- a/src/stories/autogen-test/zAIallsingleline.stories.ts
+++ b/src/stories/autogen-test/zAIallsingleline.stories.ts
@@ -1,0 +1,30 @@
+import { AiChart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('line', true);
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Line Charts",
+  render: (args) => AiChart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllSingleLineCharts: Story = {
+  name: 'All Single Line Charts',
+  args: {
+    filename: '',
+    forcecharttype: "line",
+  }
+};

--- a/src/stories/autogen-test/zAIallsinglelollipop.stories.ts
+++ b/src/stories/autogen-test/zAIallsinglelollipop.stories.ts
@@ -1,0 +1,30 @@
+import { AiChart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('bar', true);
+
+const meta = {
+  title: "AI-enhanced Charts/Bar Charts/Single Lollipop Charts",
+  render: (args) => AiChart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllSingleLollipopCharts: Story = {
+  name: 'All Single Lollipop Charts',
+  args: {
+    filename: '',
+    forcecharttype: "lollipop",
+  }
+};

--- a/src/stories/autogen-test/zAIallsinglestepline.stories.ts
+++ b/src/stories/autogen-test/zAIallsinglestepline.stories.ts
@@ -1,0 +1,30 @@
+import { AiChart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('line', true);
+
+const meta = {
+  title: "AI-enhanced Charts/Line Charts/Single Stepline Charts",
+  render: (args) => AiChart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllSingleSteplineCharts: Story = {
+  name: 'All Single Stepline Charts',
+  args: {
+    filename: '',
+    forcecharttype: "stepline",
+  }
+};

--- a/src/stories/autogen-test/zalldonut.stories.ts
+++ b/src/stories/autogen-test/zalldonut.stories.ts
@@ -1,0 +1,30 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('pastry', false);
+
+const meta = {
+  title: "Basic Charts/Pastry Charts/Donut Charts",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllDonutCharts: Story = {
+  name: 'All Donut Charts',
+  args: {
+    filename: '',
+    forcecharttype: "donut",
+  }
+};

--- a/src/stories/autogen-test/zallhistogram.stories.ts
+++ b/src/stories/autogen-test/zallhistogram.stories.ts
@@ -1,0 +1,30 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('histogram', false);
+
+const meta = {
+  title: "Basic Charts/Histograms",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllHistogramCharts: Story = {
+  name: 'All Histogram Charts',
+  args: {
+    filename: '',
+    forcecharttype: "histogram",
+  }
+};

--- a/src/stories/autogen-test/zallmultibar.stories.ts
+++ b/src/stories/autogen-test/zallmultibar.stories.ts
@@ -1,0 +1,30 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('bar', true);
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Bar Charts",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllMultiBarCharts: Story = {
+  name: 'All Multi Bar Charts',
+  args: {
+    filename: '',
+    forcecharttype: "bar",
+  }
+};

--- a/src/stories/autogen-test/zallmulticolumn.stories.ts
+++ b/src/stories/autogen-test/zallmulticolumn.stories.ts
@@ -1,0 +1,30 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('bar', true);
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Column Charts",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllMultiColumnCharts: Story = {
+  name: 'All Multi Column Charts',
+  args: {
+    filename: '',
+    forcecharttype: "column",
+  }
+};

--- a/src/stories/autogen-test/zallmultiline.stories.ts
+++ b/src/stories/autogen-test/zallmultiline.stories.ts
@@ -1,0 +1,30 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('line', true);
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Line Charts",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllMultiLineCharts: Story = {
+  name: 'All Multi Line Charts',
+  args: {
+    filename: '',
+    forcecharttype: "line",
+  }
+};

--- a/src/stories/autogen-test/zallmultilollipop.stories.ts
+++ b/src/stories/autogen-test/zallmultilollipop.stories.ts
@@ -1,0 +1,30 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('bar', true);
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Multi Lollipop Charts",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllMultiLollipopCharts: Story = {
+  name: 'All Multi Lollipop Charts',
+  args: {
+    filename: '',
+    forcecharttype: "lollipop",
+  }
+};

--- a/src/stories/autogen-test/zallmultistepline.stories.ts
+++ b/src/stories/autogen-test/zallmultistepline.stories.ts
@@ -1,0 +1,30 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('line', true);
+
+const meta = {
+  title: "Basic Charts/Line Charts/Multi Stepline Charts",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllMultiSteplineCharts: Story = {
+  name: 'All Multi Stepline Charts',
+  args: {
+    filename: '',
+    forcecharttype: "stepline",
+  }
+};

--- a/src/stories/autogen-test/zallpie.stories.ts
+++ b/src/stories/autogen-test/zallpie.stories.ts
@@ -1,0 +1,30 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('pastry', false);
+
+const meta = {
+  title: "Basic Charts/Pastry Charts/Pie Charts",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllPieCharts: Story = {
+  name: 'All Pie Charts',
+  args: {
+    filename: '',
+    forcecharttype: "pie",
+  }
+};

--- a/src/stories/autogen-test/zallscatter.stories.ts
+++ b/src/stories/autogen-test/zallscatter.stories.ts
@@ -1,0 +1,30 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('scatter', false);
+
+const meta = {
+  title: "Basic Charts/Scatter Charts",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllScatterCharts: Story = {
+  name: 'All Scatter Charts',
+  args: {
+    filename: '',
+    forcecharttype: "scatter",
+  }
+};

--- a/src/stories/autogen-test/zallsinglebar.stories.ts
+++ b/src/stories/autogen-test/zallsinglebar.stories.ts
@@ -1,0 +1,30 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('bar', true);
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Single Bar Charts",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllSingleBarCharts: Story = {
+  name: 'All Single Bar Charts',
+  args: {
+    filename: '',
+    forcecharttype: "bar",
+  }
+};

--- a/src/stories/autogen-test/zallsinglecolumn.stories.ts
+++ b/src/stories/autogen-test/zallsinglecolumn.stories.ts
@@ -1,0 +1,30 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('bar', true);
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Single Column Charts",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllSingleColumnCharts: Story = {
+  name: 'All Single Column Charts',
+  args: {
+    filename: '',
+    forcecharttype: "column",
+  }
+};

--- a/src/stories/autogen-test/zallsingleline.stories.ts
+++ b/src/stories/autogen-test/zallsingleline.stories.ts
@@ -1,0 +1,30 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('line', true);
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Line Charts",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllSingleLineCharts: Story = {
+  name: 'All Single Line Charts',
+  args: {
+    filename: '',
+    forcecharttype: "line",
+  }
+};

--- a/src/stories/autogen-test/zallsinglelollipop.stories.ts
+++ b/src/stories/autogen-test/zallsinglelollipop.stories.ts
@@ -1,0 +1,30 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('bar', true);
+
+const meta = {
+  title: "Basic Charts/Bar Charts/Single Lollipop Charts",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllSingleLollipopCharts: Story = {
+  name: 'All Single Lollipop Charts',
+  args: {
+    filename: '',
+    forcecharttype: "lollipop",
+  }
+};

--- a/src/stories/autogen-test/zallsinglestepline.stories.ts
+++ b/src/stories/autogen-test/zallsinglestepline.stories.ts
@@ -1,0 +1,30 @@
+import { Chart, type ChartProps } from '../Chart';
+import { familyManifestPathsMap } from '../chartSelectorHelper';
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+
+type Story = StoryObj<ChartProps>;
+
+const titleToFilenameMap = familyManifestPathsMap('line', true);
+
+const meta = {
+  title: "Basic Charts/Line Charts/Single Stepline Charts",
+  render: (args) => Chart(args),
+  argTypes: {
+    filename: {
+      description: 'Chart Title',
+      control: {type: 'select'},
+      options: Object.keys(titleToFilenameMap),
+      mapping: titleToFilenameMap
+    }
+  },
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const AllSingleSteplineCharts: Story = {
+  name: 'All Single Stepline Charts',
+  args: {
+    filename: '',
+    forcecharttype: "stepline",
+  }
+};

--- a/src/stories/autogen/AIbarMulti0.stories.ts
+++ b/src/stories/autogen/AIbarMulti0.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart0: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-14.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-14.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIbarMulti1.stories.ts
+++ b/src/stories/autogen/AIbarMulti1.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart1: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-149.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-149.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIbarMulti2.stories.ts
+++ b/src/stories/autogen/AIbarMulti2.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart2: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-15.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-15.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIbarMulti3.stories.ts
+++ b/src/stories/autogen/AIbarMulti3.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart3: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-178.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-178.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIbarMulti4.stories.ts
+++ b/src/stories/autogen/AIbarMulti4.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart4: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-48.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-48.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIbarMulti5.stories.ts
+++ b/src/stories/autogen/AIbarMulti5.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart5: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-61.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-61.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIbarSingle6.stories.ts
+++ b/src/stories/autogen/AIbarSingle6.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart6: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-1018.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-1018.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIbarSingle7.stories.ts
+++ b/src/stories/autogen/AIbarSingle7.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart7: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-13.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-13.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIbarSingle8.stories.ts
+++ b/src/stories/autogen/AIbarSingle8.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart8: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-27.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-27.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIcolumnMulti0.stories.ts
+++ b/src/stories/autogen/AIcolumnMulti0.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart0: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-14.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-14.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIcolumnMulti1.stories.ts
+++ b/src/stories/autogen/AIcolumnMulti1.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart1: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-149.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-149.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIcolumnMulti2.stories.ts
+++ b/src/stories/autogen/AIcolumnMulti2.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart2: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-15.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-15.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIcolumnMulti3.stories.ts
+++ b/src/stories/autogen/AIcolumnMulti3.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart3: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-178.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-178.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIcolumnMulti4.stories.ts
+++ b/src/stories/autogen/AIcolumnMulti4.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart4: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-48.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-48.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIcolumnMulti5.stories.ts
+++ b/src/stories/autogen/AIcolumnMulti5.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart5: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-61.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-61.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIcolumnSingle6.stories.ts
+++ b/src/stories/autogen/AIcolumnSingle6.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart6: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-1018.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-1018.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIcolumnSingle7.stories.ts
+++ b/src/stories/autogen/AIcolumnSingle7.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart7: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-13.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-13.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIcolumnSingle8.stories.ts
+++ b/src/stories/autogen/AIcolumnSingle8.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart8: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-27.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-27.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIdonut47.stories.ts
+++ b/src/stories/autogen/AIdonut47.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/donutTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart47: Story = {
   args: {
     filename: "manifests/pie-manifest-dark-matter.json",
     forcecharttype: "donut",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/pie-manifest-dark-matter.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineMulti10.stories.ts
+++ b/src/stories/autogen/AIlineMulti10.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart10: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-16.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-16.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineMulti11.stories.ts
+++ b/src/stories/autogen/AIlineMulti11.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart11: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-175.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-175.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineMulti12.stories.ts
+++ b/src/stories/autogen/AIlineMulti12.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart12: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-233.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-233.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineMulti13.stories.ts
+++ b/src/stories/autogen/AIlineMulti13.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart13: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-261.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-261.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineMulti14.stories.ts
+++ b/src/stories/autogen/AIlineMulti14.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart14: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-27.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-27.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineMulti15.stories.ts
+++ b/src/stories/autogen/AIlineMulti15.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart15: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-57.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-57.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineMulti16.stories.ts
+++ b/src/stories/autogen/AIlineMulti16.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart16: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-67.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-67.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineMulti17.stories.ts
+++ b/src/stories/autogen/AIlineMulti17.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart17: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-76.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-76.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineMulti18.stories.ts
+++ b/src/stories/autogen/AIlineMulti18.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart18: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-Pokemon.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-Pokemon.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineMulti9.stories.ts
+++ b/src/stories/autogen/AIlineMulti9.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart9: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-128.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-128.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle19.stories.ts
+++ b/src/stories/autogen/AIlineSingle19.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart19: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-1047.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1047.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle20.stories.ts
+++ b/src/stories/autogen/AIlineSingle20.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart20: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-1066.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1066.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle21.stories.ts
+++ b/src/stories/autogen/AIlineSingle21.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart21: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-1107.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1107.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle22.stories.ts
+++ b/src/stories/autogen/AIlineSingle22.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart22: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-128.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-128.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle23.stories.ts
+++ b/src/stories/autogen/AIlineSingle23.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart23: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-172.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-172.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle24.stories.ts
+++ b/src/stories/autogen/AIlineSingle24.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart24: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-328.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-328.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle25.stories.ts
+++ b/src/stories/autogen/AIlineSingle25.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart25: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-375.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-375.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle26.stories.ts
+++ b/src/stories/autogen/AIlineSingle26.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart26: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-489.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-489.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle27.stories.ts
+++ b/src/stories/autogen/AIlineSingle27.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart27: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-508.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-508.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle28.stories.ts
+++ b/src/stories/autogen/AIlineSingle28.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart28: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-541.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-541.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle29.stories.ts
+++ b/src/stories/autogen/AIlineSingle29.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart29: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-595.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-595.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle30.stories.ts
+++ b/src/stories/autogen/AIlineSingle30.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart30: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-605.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-605.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle31.stories.ts
+++ b/src/stories/autogen/AIlineSingle31.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart31: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-7.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-7.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle32.stories.ts
+++ b/src/stories/autogen/AIlineSingle32.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart32: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-746.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-746.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle33.stories.ts
+++ b/src/stories/autogen/AIlineSingle33.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart33: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-843.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-843.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle34.stories.ts
+++ b/src/stories/autogen/AIlineSingle34.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart34: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-881.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-881.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle35.stories.ts
+++ b/src/stories/autogen/AIlineSingle35.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart35: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-887.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-887.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle36.stories.ts
+++ b/src/stories/autogen/AIlineSingle36.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart36: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-913.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-913.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle37.stories.ts
+++ b/src/stories/autogen/AIlineSingle37.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart37: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-930.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-930.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle38.stories.ts
+++ b/src/stories/autogen/AIlineSingle38.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart38: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-937.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-937.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle39.stories.ts
+++ b/src/stories/autogen/AIlineSingle39.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart39: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-951.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-951.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle40.stories.ts
+++ b/src/stories/autogen/AIlineSingle40.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart40: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-965.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-965.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle41.stories.ts
+++ b/src/stories/autogen/AIlineSingle41.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart41: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-979.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-979.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlineSingle42.stories.ts
+++ b/src/stories/autogen/AIlineSingle42.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart42: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-Charizard.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-Charizard.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlollipopMulti0.stories.ts
+++ b/src/stories/autogen/AIlollipopMulti0.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart0: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-14.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-14.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlollipopMulti1.stories.ts
+++ b/src/stories/autogen/AIlollipopMulti1.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart1: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-149.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-149.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlollipopMulti2.stories.ts
+++ b/src/stories/autogen/AIlollipopMulti2.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart2: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-15.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-15.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlollipopMulti3.stories.ts
+++ b/src/stories/autogen/AIlollipopMulti3.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart3: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-178.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-178.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlollipopMulti4.stories.ts
+++ b/src/stories/autogen/AIlollipopMulti4.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart4: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-48.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-48.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlollipopMulti5.stories.ts
+++ b/src/stories/autogen/AIlollipopMulti5.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart5: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-61.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-61.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlollipopSingle6.stories.ts
+++ b/src/stories/autogen/AIlollipopSingle6.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart6: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-1018.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-1018.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlollipopSingle7.stories.ts
+++ b/src/stories/autogen/AIlollipopSingle7.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart7: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-13.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-13.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIlollipopSingle8.stories.ts
+++ b/src/stories/autogen/AIlollipopSingle8.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart8: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-27.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-27.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIpie47.stories.ts
+++ b/src/stories/autogen/AIpie47.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/pieTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart47: Story = {
   args: {
     filename: "manifests/pie-manifest-dark-matter.json",
     forcecharttype: "pie",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/pie-manifest-dark-matter.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIscatter49.stories.ts
+++ b/src/stories/autogen/AIscatter49.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/scatterTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart49: Story = {
   args: {
     filename: "manifests/scatter-manifest-d3.json",
     forcecharttype: "scatter",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-d3.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIscatter51.stories.ts
+++ b/src/stories/autogen/AIscatter51.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/scatterTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart51: Story = {
   args: {
     filename: "manifests/scatter-manifest-geyser.json",
     forcecharttype: "scatter",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-geyser.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIscatter54.stories.ts
+++ b/src/stories/autogen/AIscatter54.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/scatterTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart54: Story = {
   args: {
     filename: "manifests/scatter-manifest-iris-petal.json",
     forcecharttype: "scatter",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-iris-petal.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIscatter56.stories.ts
+++ b/src/stories/autogen/AIscatter56.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/scatterTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart56: Story = {
   args: {
     filename: "manifests/scatter-manifest-s1.json",
     forcecharttype: "scatter",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-s1.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIscatter58.stories.ts
+++ b/src/stories/autogen/AIscatter58.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/scatterTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart58: Story = {
   args: {
     filename: "manifests/scatter-manifest-s2.json",
     forcecharttype: "scatter",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-s2.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineMulti10.stories.ts
+++ b/src/stories/autogen/AIsteplineMulti10.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart10: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-16.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-16.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineMulti11.stories.ts
+++ b/src/stories/autogen/AIsteplineMulti11.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart11: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-175.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-175.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineMulti12.stories.ts
+++ b/src/stories/autogen/AIsteplineMulti12.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart12: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-233.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-233.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineMulti13.stories.ts
+++ b/src/stories/autogen/AIsteplineMulti13.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart13: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-261.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-261.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineMulti14.stories.ts
+++ b/src/stories/autogen/AIsteplineMulti14.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart14: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-27.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-27.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineMulti15.stories.ts
+++ b/src/stories/autogen/AIsteplineMulti15.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart15: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-57.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-57.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineMulti16.stories.ts
+++ b/src/stories/autogen/AIsteplineMulti16.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart16: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-67.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-67.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineMulti17.stories.ts
+++ b/src/stories/autogen/AIsteplineMulti17.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart17: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-76.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-76.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineMulti18.stories.ts
+++ b/src/stories/autogen/AIsteplineMulti18.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart18: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-Pokemon.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-Pokemon.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineMulti9.stories.ts
+++ b/src/stories/autogen/AIsteplineMulti9.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart9: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-128.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-128.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle19.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle19.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart19: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-1047.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1047.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle20.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle20.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart20: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-1066.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1066.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle21.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle21.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart21: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-1107.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1107.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle22.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle22.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart22: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-128.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-128.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle23.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle23.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart23: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-172.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-172.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle24.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle24.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart24: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-328.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-328.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle25.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle25.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart25: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-375.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-375.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle26.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle26.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart26: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-489.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-489.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle27.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle27.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart27: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-508.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-508.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle28.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle28.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart28: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-541.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-541.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle29.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle29.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart29: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-595.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-595.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle30.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle30.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart30: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-605.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-605.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle31.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle31.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart31: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-7.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-7.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle32.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle32.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart32: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-746.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-746.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle33.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle33.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart33: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-843.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-843.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle34.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle34.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart34: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-881.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-881.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle35.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle35.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart35: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-887.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-887.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle36.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle36.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart36: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-913.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-913.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle37.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle37.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart37: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-930.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-930.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle38.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle38.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart38: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-937.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-937.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle39.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle39.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart39: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-951.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-951.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle40.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle40.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart40: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-965.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-965.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle41.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle41.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart41: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-979.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-979.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/AIsteplineSingle42.stories.ts
+++ b/src/stories/autogen/AIsteplineSingle42.stories.ts
@@ -1,9 +1,6 @@
 import { AiChart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const AiChart42: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-Charizard.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-Charizard.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/barMulti0.stories.ts
+++ b/src/stories/autogen/barMulti0.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart0: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-14.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-14.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/barMulti1.stories.ts
+++ b/src/stories/autogen/barMulti1.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart1: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-149.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-149.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/barMulti2.stories.ts
+++ b/src/stories/autogen/barMulti2.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart2: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-15.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-15.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/barMulti3.stories.ts
+++ b/src/stories/autogen/barMulti3.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart3: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-178.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-178.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/barMulti4.stories.ts
+++ b/src/stories/autogen/barMulti4.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart4: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-48.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-48.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/barMulti5.stories.ts
+++ b/src/stories/autogen/barMulti5.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart5: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-61.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-61.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/barSingle6.stories.ts
+++ b/src/stories/autogen/barSingle6.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart6: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-1018.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-1018.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/barSingle7.stories.ts
+++ b/src/stories/autogen/barSingle7.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart7: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-13.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-13.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/barSingle8.stories.ts
+++ b/src/stories/autogen/barSingle8.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/barTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart8: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-27.json",
     forcecharttype: "bar",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-27.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/columnMulti0.stories.ts
+++ b/src/stories/autogen/columnMulti0.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart0: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-14.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-14.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/columnMulti1.stories.ts
+++ b/src/stories/autogen/columnMulti1.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart1: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-149.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-149.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/columnMulti2.stories.ts
+++ b/src/stories/autogen/columnMulti2.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart2: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-15.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-15.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/columnMulti3.stories.ts
+++ b/src/stories/autogen/columnMulti3.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart3: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-178.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-178.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/columnMulti4.stories.ts
+++ b/src/stories/autogen/columnMulti4.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart4: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-48.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-48.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/columnMulti5.stories.ts
+++ b/src/stories/autogen/columnMulti5.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart5: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-61.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-61.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/columnSingle6.stories.ts
+++ b/src/stories/autogen/columnSingle6.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart6: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-1018.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-1018.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/columnSingle7.stories.ts
+++ b/src/stories/autogen/columnSingle7.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart7: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-13.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-13.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/columnSingle8.stories.ts
+++ b/src/stories/autogen/columnSingle8.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/columnTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart8: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-27.json",
     forcecharttype: "column",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-27.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/donut47.stories.ts
+++ b/src/stories/autogen/donut47.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/donutTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart47: Story = {
   args: {
     filename: "manifests/pie-manifest-dark-matter.json",
     forcecharttype: "donut",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/pie-manifest-dark-matter.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineMulti10.stories.ts
+++ b/src/stories/autogen/lineMulti10.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart10: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-16.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-16.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineMulti11.stories.ts
+++ b/src/stories/autogen/lineMulti11.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart11: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-175.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-175.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineMulti12.stories.ts
+++ b/src/stories/autogen/lineMulti12.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart12: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-233.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-233.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineMulti13.stories.ts
+++ b/src/stories/autogen/lineMulti13.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart13: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-261.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-261.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineMulti14.stories.ts
+++ b/src/stories/autogen/lineMulti14.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart14: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-27.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-27.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineMulti15.stories.ts
+++ b/src/stories/autogen/lineMulti15.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart15: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-57.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-57.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineMulti16.stories.ts
+++ b/src/stories/autogen/lineMulti16.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart16: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-67.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-67.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineMulti17.stories.ts
+++ b/src/stories/autogen/lineMulti17.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart17: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-76.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-76.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineMulti18.stories.ts
+++ b/src/stories/autogen/lineMulti18.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart18: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-Pokemon.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-Pokemon.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineMulti9.stories.ts
+++ b/src/stories/autogen/lineMulti9.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart9: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-128.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-128.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle19.stories.ts
+++ b/src/stories/autogen/lineSingle19.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart19: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-1047.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1047.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle20.stories.ts
+++ b/src/stories/autogen/lineSingle20.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart20: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-1066.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1066.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle21.stories.ts
+++ b/src/stories/autogen/lineSingle21.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart21: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-1107.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1107.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle22.stories.ts
+++ b/src/stories/autogen/lineSingle22.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart22: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-128.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-128.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle23.stories.ts
+++ b/src/stories/autogen/lineSingle23.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart23: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-172.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-172.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle24.stories.ts
+++ b/src/stories/autogen/lineSingle24.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart24: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-328.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-328.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle25.stories.ts
+++ b/src/stories/autogen/lineSingle25.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart25: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-375.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-375.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle26.stories.ts
+++ b/src/stories/autogen/lineSingle26.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart26: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-489.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-489.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle27.stories.ts
+++ b/src/stories/autogen/lineSingle27.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart27: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-508.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-508.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle28.stories.ts
+++ b/src/stories/autogen/lineSingle28.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart28: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-541.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-541.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle29.stories.ts
+++ b/src/stories/autogen/lineSingle29.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart29: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-595.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-595.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle30.stories.ts
+++ b/src/stories/autogen/lineSingle30.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart30: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-605.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-605.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle31.stories.ts
+++ b/src/stories/autogen/lineSingle31.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart31: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-7.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-7.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle32.stories.ts
+++ b/src/stories/autogen/lineSingle32.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart32: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-746.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-746.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle33.stories.ts
+++ b/src/stories/autogen/lineSingle33.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart33: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-843.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-843.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle34.stories.ts
+++ b/src/stories/autogen/lineSingle34.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart34: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-881.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-881.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle35.stories.ts
+++ b/src/stories/autogen/lineSingle35.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart35: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-887.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-887.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle36.stories.ts
+++ b/src/stories/autogen/lineSingle36.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart36: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-913.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-913.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle37.stories.ts
+++ b/src/stories/autogen/lineSingle37.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart37: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-930.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-930.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle38.stories.ts
+++ b/src/stories/autogen/lineSingle38.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart38: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-937.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-937.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle39.stories.ts
+++ b/src/stories/autogen/lineSingle39.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart39: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-951.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-951.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle40.stories.ts
+++ b/src/stories/autogen/lineSingle40.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart40: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-965.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-965.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle41.stories.ts
+++ b/src/stories/autogen/lineSingle41.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart41: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-979.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-979.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lineSingle42.stories.ts
+++ b/src/stories/autogen/lineSingle42.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart42: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-Charizard.json",
     forcecharttype: "line",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-Charizard.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lollipopMulti0.stories.ts
+++ b/src/stories/autogen/lollipopMulti0.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart0: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-14.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-14.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lollipopMulti1.stories.ts
+++ b/src/stories/autogen/lollipopMulti1.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart1: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-149.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-149.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lollipopMulti2.stories.ts
+++ b/src/stories/autogen/lollipopMulti2.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart2: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-15.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-15.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lollipopMulti3.stories.ts
+++ b/src/stories/autogen/lollipopMulti3.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart3: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-178.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-178.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lollipopMulti4.stories.ts
+++ b/src/stories/autogen/lollipopMulti4.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart4: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-48.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-48.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lollipopMulti5.stories.ts
+++ b/src/stories/autogen/lollipopMulti5.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart5: Story = {
   args: {
     filename: "manifests/autogen/bar-multi/bar-multi-manifest-61.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-multi/bar-multi-manifest-61.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lollipopSingle6.stories.ts
+++ b/src/stories/autogen/lollipopSingle6.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart6: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-1018.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-1018.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lollipopSingle7.stories.ts
+++ b/src/stories/autogen/lollipopSingle7.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart7: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-13.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-13.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/lollipopSingle8.stories.ts
+++ b/src/stories/autogen/lollipopSingle8.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/lollipopTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart8: Story = {
   args: {
     filename: "manifests/autogen/bar-single/bar-single-manifest-27.json",
     forcecharttype: "lollipop",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/bar-single/bar-single-manifest-27.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/pie47.stories.ts
+++ b/src/stories/autogen/pie47.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/pieTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart47: Story = {
   args: {
     filename: "manifests/pie-manifest-dark-matter.json",
     forcecharttype: "pie",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/pie-manifest-dark-matter.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/scatter49.stories.ts
+++ b/src/stories/autogen/scatter49.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/scatterTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart49: Story = {
   args: {
     filename: "manifests/scatter-manifest-d3.json",
     forcecharttype: "scatter",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-d3.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/scatter51.stories.ts
+++ b/src/stories/autogen/scatter51.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/scatterTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart51: Story = {
   args: {
     filename: "manifests/scatter-manifest-geyser.json",
     forcecharttype: "scatter",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-geyser.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/scatter54.stories.ts
+++ b/src/stories/autogen/scatter54.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/scatterTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart54: Story = {
   args: {
     filename: "manifests/scatter-manifest-iris-petal.json",
     forcecharttype: "scatter",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-iris-petal.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/scatter56.stories.ts
+++ b/src/stories/autogen/scatter56.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/scatterTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart56: Story = {
   args: {
     filename: "manifests/scatter-manifest-s1.json",
     forcecharttype: "scatter",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-s1.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/scatter58.stories.ts
+++ b/src/stories/autogen/scatter58.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/scatterTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart58: Story = {
   args: {
     filename: "manifests/scatter-manifest-s2.json",
     forcecharttype: "scatter",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/scatter-manifest-s2.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineMulti10.stories.ts
+++ b/src/stories/autogen/steplineMulti10.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart10: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-16.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-16.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineMulti11.stories.ts
+++ b/src/stories/autogen/steplineMulti11.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart11: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-175.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-175.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineMulti12.stories.ts
+++ b/src/stories/autogen/steplineMulti12.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart12: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-233.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-233.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineMulti13.stories.ts
+++ b/src/stories/autogen/steplineMulti13.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart13: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-261.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-261.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineMulti14.stories.ts
+++ b/src/stories/autogen/steplineMulti14.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart14: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-27.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-27.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineMulti15.stories.ts
+++ b/src/stories/autogen/steplineMulti15.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart15: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-57.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-57.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineMulti16.stories.ts
+++ b/src/stories/autogen/steplineMulti16.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart16: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-67.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-67.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineMulti17.stories.ts
+++ b/src/stories/autogen/steplineMulti17.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart17: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-76.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-76.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineMulti18.stories.ts
+++ b/src/stories/autogen/steplineMulti18.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart18: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-Pokemon.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-Pokemon.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineMulti9.stories.ts
+++ b/src/stories/autogen/steplineMulti9.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart9: Story = {
   args: {
     filename: "manifests/autogen/line-multi/line-multi-manifest-128.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-multi/line-multi-manifest-128.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle19.stories.ts
+++ b/src/stories/autogen/steplineSingle19.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart19: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-1047.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1047.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle20.stories.ts
+++ b/src/stories/autogen/steplineSingle20.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart20: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-1066.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1066.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle21.stories.ts
+++ b/src/stories/autogen/steplineSingle21.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart21: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-1107.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-1107.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle22.stories.ts
+++ b/src/stories/autogen/steplineSingle22.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart22: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-128.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-128.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle23.stories.ts
+++ b/src/stories/autogen/steplineSingle23.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart23: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-172.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-172.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle24.stories.ts
+++ b/src/stories/autogen/steplineSingle24.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart24: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-328.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-328.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle25.stories.ts
+++ b/src/stories/autogen/steplineSingle25.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart25: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-375.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-375.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle26.stories.ts
+++ b/src/stories/autogen/steplineSingle26.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart26: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-489.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-489.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle27.stories.ts
+++ b/src/stories/autogen/steplineSingle27.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart27: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-508.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-508.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle28.stories.ts
+++ b/src/stories/autogen/steplineSingle28.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart28: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-541.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-541.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle29.stories.ts
+++ b/src/stories/autogen/steplineSingle29.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart29: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-595.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-595.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle30.stories.ts
+++ b/src/stories/autogen/steplineSingle30.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart30: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-605.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-605.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle31.stories.ts
+++ b/src/stories/autogen/steplineSingle31.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart31: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-7.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-7.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle32.stories.ts
+++ b/src/stories/autogen/steplineSingle32.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart32: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-746.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-746.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle33.stories.ts
+++ b/src/stories/autogen/steplineSingle33.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart33: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-843.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-843.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle34.stories.ts
+++ b/src/stories/autogen/steplineSingle34.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart34: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-881.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-881.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle35.stories.ts
+++ b/src/stories/autogen/steplineSingle35.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart35: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-887.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-887.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle36.stories.ts
+++ b/src/stories/autogen/steplineSingle36.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart36: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-913.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-913.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle37.stories.ts
+++ b/src/stories/autogen/steplineSingle37.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart37: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-930.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-930.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle38.stories.ts
+++ b/src/stories/autogen/steplineSingle38.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart38: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-937.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-937.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle39.stories.ts
+++ b/src/stories/autogen/steplineSingle39.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart39: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-951.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-951.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle40.stories.ts
+++ b/src/stories/autogen/steplineSingle40.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart40: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-965.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-965.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle41.stories.ts
+++ b/src/stories/autogen/steplineSingle41.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart41: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-979.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-979.json");
-    await runner.run();
   }
 }

--- a/src/stories/autogen/steplineSingle42.stories.ts
+++ b/src/stories/autogen/steplineSingle42.stories.ts
@@ -1,9 +1,6 @@
 import { Chart, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/steplineTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,9 +16,5 @@ export const Chart42: Story = {
   args: {
     filename: "manifests/autogen/line-single/line-single-manifest-Charizard.json",
     forcecharttype: "stepline",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("manifests/autogen/line-single/line-single-manifest-Charizard.json");
-    await runner.run();
   }
 }

--- a/src/stories/storyTemplate.ts
+++ b/src/stories/storyTemplate.ts
@@ -1,9 +1,6 @@
 export const template = `import { %(chartElement)s, type ChartProps } from '../Chart';
 
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import { expect } from 'storybook/test';
-
-import Runner from '../tests/%(chartType)sTests';
 
 type Story = StoryObj<ChartProps>;
 
@@ -19,10 +16,6 @@ export const %(chartElement)s%(index)s: Story = {
   args: {
     filename: "%(manifestPath)s",
     forcecharttype: "%(chartType)s",
-  },
-  play: async ({canvas, userEvent}) => {
-    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("%(manifestPath)s");
-    await runner.run();
   }
 }
 `

--- a/src/stories/testStoriesTemplate.ts
+++ b/src/stories/testStoriesTemplate.ts
@@ -1,0 +1,28 @@
+export const template = `import { %(chartElement)s, type ChartProps } from '../Chart';
+
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { expect } from 'storybook/test';
+
+import Runner from '../tests/%(chartType)sTests';
+
+type Story = StoryObj<ChartProps>;
+
+const meta = {
+  title: "%(topFolder)s/%(typeFolder)s",
+  render: (args) => %(chartElement)s(args),
+} satisfies Meta<ChartProps>;
+
+export default meta;
+
+export const %(chartElement)s%(index)s: Story = {
+  name: "%(manifestTitle)s",
+  args: {
+    filename: "%(manifestPath)s",
+    forcecharttype: "%(chartType)s",
+  },
+  play: async ({canvas, userEvent}) => {
+    const runner = await (new Runner(canvas, userEvent, expect)).loadManifest("%(manifestPath)s");
+    await runner.run();
+  }
+}
+`


### PR DESCRIPTION
This PR makes sure that no tests are running during demos by separating autogenerated stories into two directories: `src/stories/autogen` and `src/stories/autogen-test`. To run the version without tests, run `npm run dev`, and to run the tests, run `npm run dev:test`. This fixes the issue we saw last week where console errors from storybook tests were showing up during demos.