### PR TITLE
Fixing bug with open/close button of control panel

### DIFF
--- a/lib/control_panel/control_panel.ts
+++ b/lib/control_panel/control_panel.ts
@@ -252,7 +252,7 @@ export class ParaControlPanel extends logging(ParaComponent) {
           ?open=${this.settings.isControlPanelDefaultOpen}
           class=${deetsState}
           tablabelmode=${tabLabelModes[this.settings.tabLabelStyle]}
-          openbuttonarialabel="Open or close ParaCharts control panel"
+		  openbuttonarialabel="ParaCharts control panel"
           @open=${
             () => {
               this.paraChart.isControlPanelOpen = true;


### PR DESCRIPTION
Previously, the open/close button was saying "unlabeled button" because openbuttonarialabel wasn't properly defined in ui-components. The only change I'm making here is changing the text of the aria-label to "ParaCharts control panel" as opposed to "Open or close ParaCharts control panel" to make it more concise. The "open or close" part is unnecessary since the aria-expanded attribute already communicates to the user that it's expandable and collapsible.  