### PR TITLE
Add scrollyteller to ParaChart class

### DIFF
--- a/lib/parachart/parachart.ts
+++ b/lib/parachart/parachart.ts
@@ -35,6 +35,7 @@ import '../components/aria_live';
 import { StyleManager } from './style_manager';
 import { AvailableCommands, Commander } from './commander';
 import { ParaPerformer } from '../paraperformer/paraperformer';
+import { Scrollyteller } from '../scrollyteller/scrollyteller';
 
 import { Manifest } from '@fizz/paramanifest';
 
@@ -77,6 +78,7 @@ export class ParaChart extends logging(ParaComponent) {
   protected _styleManager!: StyleManager;
   protected _commander!: Commander;
   protected _performer!: ParaPerformer;
+  protected _scrollyteller: Scrollyteller;
 
   constructor(
     seriesAnalyzerConstructor?: SeriesAnalyzerConstructor,
@@ -101,6 +103,7 @@ export class ParaChart extends logging(ParaComponent) {
     customPropLoader.registerColors();
     customPropLoader.registerSymbols();
     this._api = new ParaApi(this);
+    this._scrollyteller = new Scrollyteller(this);
 
     this._loaderPromise = new Promise((resolve, reject) => {
       this._loaderResolver = resolve;
@@ -185,6 +188,10 @@ export class ParaChart extends logging(ParaComponent) {
 
   get performer() {
     return this._performer;
+  }
+
+  get scrollyteller() {
+    return this._scrollyteller;
   }
 
   connectedCallback() {


### PR DESCRIPTION
This PR adds a protected `_scrollyteller` member to the ParaChart class with a corresponding `scrollyteller` accessor method.
The purpose of this addition is that every ParaChart object now instantiates a `Scrollyteller` object and passes a reference to itself to the `Scrollyteller` constructor, so that every `Scrollyteller` object can keep track of the `ParaChart` it is managing.