### PR TITLE
Fix paraperformer bug

### DIFF
--- a/lib/paraperformer/paraperformer.ts
+++ b/lib/paraperformer/paraperformer.ts
@@ -28,7 +28,7 @@ export class ParaPerformer {
   protected _allSeries: ParaPerformerSeries[];
 
   static getInst(paraChart: ParaChart): ParaPerformer {
-    if (!ParaPerformer._inst) {
+    if (!ParaPerformer._inst || ParaPerformer._inst.paraChart.manifest !== paraChart.manifest) {
       ParaPerformer._inst = new ParaPerformer(paraChart);
     }
     return ParaPerformer._inst;


### PR DESCRIPTION
Provisional fix to #709 
Adds a check that the manifest being used by the ParaChart referenced by the ParaPerformer instance is the same one being used by the ParaChart that is calling on said ParaPerformer instance.
This appears to work as I intended but there may need to be a more thorough solution, I'm not too familiar with the code in question