### PR TITLE
Fix legend lowlighting

### DIFF
--- a/lib/chart_types/bar_chart.ts
+++ b/lib/chart_types/bar_chart.ts
@@ -193,18 +193,21 @@ export class BarChartInfo extends PlaneChartInfo {
   }
 
   legend() {
+    const model = this._store.model!;
     if (this._store.settings.legend.itemOrder === 'series') {
       // return this._chartLandingView.children.map(view => ({
       //   label: (view as SeriesView).seriesKey,
       //   color: (view as SeriesView).color  // series color
       // }));
-      return this._store.model!.series.map(series => ({
+      return model.series.map(series => ({
         label: series.getLabel(),
+        seriesKey: series.key,
         color: this._store.seriesProperties!.properties(series.key).color
       }));
     } else {
-      return this._store.model!.seriesKeys.toSorted().map(key => ({
-        label: this._store.model!.atKey(key)!.getLabel(),
+      return model.seriesKeys.toSorted().map(key => ({
+        label: model.atKey(key)!.getLabel(),
+        seriesKey: key,
         color: this._store.seriesProperties!.properties(key).color
       }));
     }

--- a/lib/chart_types/base_chart.ts
+++ b/lib/chart_types/base_chart.ts
@@ -165,6 +165,7 @@ export abstract class BaseChartInfo {
     return seriesInNavOrder.map((key, i) => (
       {
         label: '',
+        seriesKey: key,
         color: this._store.seriesProperties!.properties(key).color,
         symbol: this._store.seriesProperties!.properties(key).symbol,
       }));

--- a/lib/chart_types/line_chart.ts
+++ b/lib/chart_types/line_chart.ts
@@ -216,12 +216,14 @@ export class LineChartInfo extends PointChartInfo {
   }
 
   legend() {
-    const seriesKeys = [...this._store.model!.seriesKeys];
+    const model = this._store.model!;
+    const seriesKeys = [...model.seriesKeys];
     if (this._store.settings.legend.itemOrder === 'alphabetical') {
       seriesKeys.sort();
     }
     return seriesKeys.map(key => ({
-      label: key,
+      label: model.atKey(key)!.getLabel(),
+      seriesKey: key,
       color: this._store.seriesProperties!.properties(key).color
     }));
   }

--- a/lib/chart_types/pastry_chart.ts
+++ b/lib/chart_types/pastry_chart.ts
@@ -100,12 +100,14 @@ export class PastryChartInfo extends BaseChartInfo {
   }
 
   legend() {
-    const xs = this._store.model!.series[0].datapoints.map(dp =>
+    const series = this._store.model!.series[0];
+    const xs = series.datapoints.map(dp =>
       formatBox(dp.facetBox('x')!, this._store.getFormatType('pieSliceLabel')));
-    const ys = this._store.model!.series[0].datapoints.map(dp =>
+    const ys = series.datapoints.map(dp =>
       formatBox(dp.facetBox('y')!, this._store.getFormatType('pieSliceValue')));
     return xs.map((x, i) => ({
       label: `${x}: ${ys[i]}`,
+      seriesKey: series.key,
       color: i,
       datapointIndex: i
     }));

--- a/lib/view/layers/popup_layer.ts
+++ b/lib/view/layers/popup_layer.ts
@@ -156,7 +156,7 @@ export class PopupLayer extends PlotLayer {
         this.paraview.documentView?.chartLayers.backgroundAnnotationLayer.render()!;
         const popup = new Popup(this.paraview,
             {
-                text: text,
+                text,
                 x: dpView!.x,
                 y: dpView!.y,
                 textAnchor: "middle",
@@ -165,7 +165,7 @@ export class PopupLayer extends PlotLayer {
                 color: dpView!.color,
                 //margin: 60,
                 type: "chord",
-                items: items,
+                items,
                 points: datapointViews
             },
             {

--- a/lib/view/legend.ts
+++ b/lib/view/legend.ts
@@ -16,6 +16,7 @@ export type SeriesAttrs = {
 
 export interface LegendItem {
   label: string;
+  seriesKey: string;
   symbol?: DataSymbolType;
   color: number;
   datapointIndex?: number;
@@ -78,8 +79,7 @@ export class Legend extends Container(View) {
         {
           color: item.color,
           pointerEnter: (e) => {
-            // XXX should use key
-            this.paraview.store.lowlightOtherSeries(item.label);
+            this.paraview.store.lowlightOtherSeries(item.seriesKey);
           },
           pointerLeave: (e) => {
             this.paraview.store.clearAllSeriesLowlights();
@@ -93,7 +93,7 @@ export class Legend extends Container(View) {
         textAnchor: 'start',
         classList: ['legend-label'],
         pointerEnter: (e) => {
-          this.paraview.store.lowlightOtherSeries(item.label);
+          this.paraview.store.lowlightOtherSeries(item.seriesKey);
         },
         pointerLeave: (e) => {
           this.paraview.store.clearAllSeriesLowlights();


### PR DESCRIPTION
`lowlightOtherSeries` in `Legend` now uses the series key, rather than the label, so the non-lowlighted series is now selected correctly. This required adding a `seriesKey` property to `LegendItem`. Closes #791