### PR TITLE
Added new API calls for descriptions

### DIFF
--- a/etc/paracharts.ai.api.md
+++ b/etc/paracharts.ai.api.md
@@ -24,6 +24,7 @@ import { FormatType } from '@fizz/parasummary';
 import { Highlight as Highlight_2 } from '@fizz/parasummary';
 import { HighlightedSummary } from '@fizz/parasummary';
 import { Interval } from '@fizz/chart-classifier-utils';
+import type { Jim } from '@fizz/jimerator';
 import { Jimerator } from '@fizz/jimerator';
 import { LitElement } from 'lit';
 import { Logger } from '@fizz/logger';

--- a/etc/paracharts.api.md
+++ b/etc/paracharts.api.md
@@ -24,6 +24,7 @@ import { FormatType } from '@fizz/parasummary';
 import { Highlight as Highlight_2 } from '@fizz/parasummary';
 import { HighlightedSummary } from '@fizz/parasummary';
 import { Interval } from '@fizz/chart-classifier-utils';
+import type { Jim } from '@fizz/jimerator';
 import { Jimerator } from '@fizz/jimerator';
 import { LitElement } from 'lit';
 import { Logger } from '@fizz/logger';

--- a/lib/chart_types/base_chart.ts
+++ b/lib/chart_types/base_chart.ts
@@ -33,7 +33,7 @@ import { Summarizer, formatBox, Highlight, summarizerFromModel } from '@fizz/par
 import { Unsubscribe } from '@lit-app/state';
 import { executeParaActions, parseAction } from '../paraactions/paraactions';
 
-const ORIENTATION_SENTENCES = [
+export const ORIENTATION_SENTENCES = [
   '$.datasets[0].axes.dependent',
   '$.datasets[0].axes.independent',
   '$.datasets[0].labels'

--- a/lib/control_panel/caption.ts
+++ b/lib/control_panel/caption.ts
@@ -7,8 +7,6 @@ import { HighlightedSummary } from '@fizz/parasummary';
 
 import { html, css, TemplateResult, PropertyValues } from 'lit';
 import { property, customElement, state } from 'lit/decorators.js';
-import { ref, createRef } from 'lit/directives/ref.js';
-import { styleMap } from 'lit/directives/style-map.js';
 import { type Unsubscribe } from '@lit-app/state';
 import { ParaChart } from '../parachart/parachart';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
@@ -73,6 +71,10 @@ export class ParaCaptionBox extends ParaComponent {
 
   get highlightManualOverride() {
     return this._highlightManualOverride;
+  }
+
+  get caption() {
+    return this._caption;
   }
 
   connectedCallback(): void {

--- a/lib/paraapi/paraapi.ts
+++ b/lib/paraapi/paraapi.ts
@@ -16,10 +16,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 
 import { type Datapoint } from '@fizz/paramodel';
 
-import { type BaseChartInfo } from '../chart_types';
+import { ORIENTATION_SENTENCES, type BaseChartInfo } from '../chart_types';
 import { type ParaChart } from '../parachart/parachart';
 import { Direction, makeSequenceId, Setting, SettingsManager } from '../state';
 import { ActionArgumentMap, AvailableActions } from '../state/action_map';
+import type { Jim } from '@fizz/jimerator'
 
 type Actions = { [Property in keyof AvailableActions]: ((args?: ActionArgumentMap) => void | Promise<void>) };
 
@@ -251,6 +252,18 @@ export class ParaAPI {
 
   serializeChart() {
     return this._paraChart.paraView.serialize();
+  }
+
+  async getDescription() {
+    return this._paraChart.paraView.documentView?.chartInfo.summarizer.getChartSummary();
+  }
+
+  async getAltText() {
+    return this.paraChart.captionBox.renderSummary(await this.paraChart.paraView.documentView!.chartInfo.summarizer.getRequestedSummaries(ORIENTATION_SENTENCES), 'statusbar');
+  }
+
+  getJIM(): Jim | undefined {
+    return this.paraChart.paraState.jimerator?.jim
   }
 
   downloadSVG() {

--- a/lib/view/data/datapoint.ts
+++ b/lib/view/data/datapoint.ts
@@ -385,6 +385,9 @@ export class DatapointView extends DataView {
         fill = this.datapoint.facetValueAsNumber('y')! >= 0
           ? pal.colors[0].value
           : pal.colors[1].value;
+        y = this.datapoint.facetValueAsNumber('y')! >= 0
+          ? y
+          : y + this.height;
       } else {
         fill = pal.colors[2].value;
       }

--- a/lib/view/layers/data/chart_type/plane_plot_view.ts
+++ b/lib/view/layers/data/chart_type/plane_plot_view.ts
@@ -205,11 +205,12 @@ export abstract class PlanePlotView extends DataLayer {
       horizLabels.push(horizLabel);
     }
     else {
+      const isColumn = this.paraview.paraState.type === 'column';
       const vertLabelText = String(nearestPoint.datapoint.facetBox("x")!.raw);
       const horizLabelText = String(nearestPoint.datapoint.facetBox("y")!.raw);
       const vertLabel = new Popup(this.paraview, {
         text: vertLabelText,
-        x: nearestPoint.x,
+        x: isColumn ? nearestPoint.x + nearestPoint.width / 2 : nearestPoint.x,
         y: this.height,
         margin: 0,
         fill: "black"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1726,7 +1726,8 @@
       "version": "0.2.1",
       "resolved": "https://npm.fizz.studio/@fizz/chart-data-norm/-/chart-data-norm-0.2.1.tgz",
       "integrity": "sha512-YmBTWNT3w0yI53Hh2mwcVtCqHNamrwfaK/sfFZ3D2+7WYjBPl7SRHIaY0TWhTXuT2kzMuLc7IfG47xlbdUL9SA==",
-      "license": "UNLICENSED"
+      "license": "UNLICENSED",
+      "optional": true
     },
     "node_modules/@fizz/chart-data/node_modules/@apidevtools/json-schema-ref-parser": {
       "version": "11.9.3",
@@ -1805,6 +1806,7 @@
       "resolved": "https://npm.fizz.studio/@fizz/chart-message/-/chart-message-0.19.0.tgz",
       "integrity": "sha512-1lpPczPFSf9s1ba/4eKl2Ve5Qs6DjHl1+qFhlzMSHOMM0KY8i9yHeuC4Om+z2o6kivd7MgITlb1JYHvZ01U/iQ==",
       "license": "UNLICENSED",
+      "optional": true,
       "dependencies": {
         "@fizz/chart-classifier-utils": "^0.16.0",
         "@fizz/jsbayes": "^0.6.1",
@@ -1904,7 +1906,8 @@
       "version": "0.6.1",
       "resolved": "https://npm.fizz.studio/@fizz/jsbayes/-/jsbayes-0.6.1.tgz",
       "integrity": "sha512-DvVi391YNrGPHXkKy+ogHjgajUjheYdF7D8XbPBEVaGUHnh+OyxOqwSQdit8U480YhGemtpNAEt++jE2dfTOtQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/@fizz/jsrealb": {
       "version": "4.0.3",
@@ -1916,13 +1919,15 @@
       "version": "3.10.2",
       "resolved": "https://npm.fizz.studio/@fizz/line-chart/-/line-chart-3.10.2.tgz",
       "integrity": "sha512-Fdr5Hxhey7+y0ZGoMmXn4QSV2Wrju7ugUAoeGdQW3tRGZYnrD9R3/M3+lkeLN1zcSLHlyJsL6OhXWxUBHuueOA==",
-      "license": "UNLICENSED"
+      "license": "UNLICENSED",
+      "optional": true
     },
     "node_modules/@fizz/line-chart-ui-utils": {
       "version": "0.8.0",
       "resolved": "https://npm.fizz.studio/@fizz/line-chart-ui-utils/-/line-chart-ui-utils-0.8.0.tgz",
       "integrity": "sha512-Ro6w3x6Rk4ljgf0ATcXSwiSrr1eNS89AfBGZ0NM1A9L4vzjdEQP1LN1hulGE5fWZgKwgc16zE6KQI4JWLHcC+A==",
       "license": "UNLICENSED",
+      "optional": true,
       "dependencies": {
         "@fizz/chart-classifier-utils": "^0.16.0",
         "@fizz/chart-data-norm": "^0.2.1",
@@ -2064,21 +2069,6 @@
         "@bitacode/tokenator": "^1.0.5"
       }
     },
-    "node_modules/@fizz/parasummary/node_modules/@fizz/series-analyzer": {
-      "version": "0.13.8",
-      "resolved": "https://npm.fizz.studio/@fizz/series-analyzer/-/series-analyzer-0.13.8.tgz",
-      "integrity": "sha512-nZ5jkF8R5pvn+O2wchWvACYR8qvXd2x9deaD6Lw9n1ZL01inI6BGOK7SSSjJOix3OERH2cuKdjQpIf7yWEjFuQ==",
-      "license": "UNLICENSED",
-      "optional": true,
-      "dependencies": {
-        "@fizz/breakdancer": "^0.24.0",
-        "@fizz/chart-classifier-utils": "^0.16.1",
-        "@fizz/chart-message": "^0.19.0",
-        "@fizz/chart-message-candidates": "^0.28.1",
-        "@fizz/line-chart-ui-utils": "^0.8.0",
-        "simple-statistics": "^7.8.3"
-      }
-    },
     "node_modules/@fizz/segmentation-feature-matrix": {
       "version": "2.13.0",
       "resolved": "https://npm.fizz.studio/@fizz/segmentation-feature-matrix/-/segmentation-feature-matrix-2.13.0.tgz",
@@ -2095,6 +2085,7 @@
       "resolved": "https://npm.fizz.studio/@fizz/series-analyzer/-/series-analyzer-0.13.9.tgz",
       "integrity": "sha512-80s+L8v5bkBIeLlZy1J/bnCNhxV41i8+40kYaf87A8JWUHC55/KZp59dcoes8hyQk9+LH1rV/ADWoPvH7JApxw==",
       "license": "UNLICENSED",
+      "optional": true,
       "dependencies": {
         "@fizz/breakdancer": "^0.24.0",
         "@fizz/chart-classifier-utils": "^0.16.1",


### PR DESCRIPTION
Adds new API calls. `getJIM()` returns the JIM associated with the chart. `getDescription()` returns the default chart summary that appears in the caption upon the chart loading in a `Promise<HighlightedSummary>` object that contains both the raw text and a highlighted html. `getAltText()` returns the text that displays in the exploration bar while focused on the top level of a chart in a `TemplateResult` object.