### PR TITLE
Adds independent value labels to pastry record count sentences

### DIFF
--- a/lib/chart_types/base_chart.ts
+++ b/lib/chart_types/base_chart.ts
@@ -36,11 +36,11 @@ import { executeParaActions, parseAction } from '../paraactions/paraactions';
 export const ORIENTATION_SENTENCES = [
   '$.datasets[0].axes.dependent',
   '$.datasets[0].axes.independent',
-  '$.datasets[0].labels'
+  '$.datasets[0].recordCount'
 ]
 
 export const PASTRY_ORIENTATION_SENTENCES = [
-  '$.datasets[0].labels',
+  '$.datasets[0].recordCount',
 ]
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fizz/logger": "^0.1.0",
         "@fizz/paramanifest": "^0.10.2",
         "@fizz/paramodel": "^0.6.22",
-        "@fizz/parasummary": "^0.11.3",
+        "@fizz/parasummary": "^0.11.4",
         "@fizz/sparkbraille-component": "^0.5.0",
         "@fizz/templum": "^0.4.4",
         "@fizz/ui-components": "^0.70.5",
@@ -1968,9 +1968,9 @@
       }
     },
     "node_modules/@fizz/parasummary": {
-      "version": "0.11.3",
-      "resolved": "https://npm.fizz.studio/@fizz/parasummary/-/parasummary-0.11.3.tgz",
-      "integrity": "sha512-Kit24Zq8k1sMghxUtppzFTRjrSlP24aSzZHKqiJiCDD22rpXixTgYKKMz9vAML70iO/cSl0WOIdAwAz0uKCwNg==",
+      "version": "0.11.4",
+      "resolved": "https://npm.fizz.studio/@fizz/parasummary/-/parasummary-0.11.4.tgz",
+      "integrity": "sha512-gtaERPa1w7xm3UfkjkMVGryqZm6evtYHkY8HdCa8ci8LuiJU1Vn1zDjguvY0LR3tXFJcrX8VputQoC1H9JrdLQ==",
       "license": "UNLICENSED",
       "dependencies": {
         "@fizz/chart-classifier-utils": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@fizz/logger": "^0.1.0",
     "@fizz/paramanifest": "^0.10.2",
     "@fizz/paramodel": "^0.6.22",
-    "@fizz/parasummary": "^0.11.3",
+    "@fizz/parasummary": "^0.11.4",
     "@fizz/sparkbraille-component": "^0.5.0",
     "@fizz/templum": "^0.4.4",
     "@fizz/ui-components": "^0.70.5",


### PR DESCRIPTION
Adds independent value labels to pastry record count sentences. See https://github.com/fizzstudio/ParaSummary/issues/76

Also onverted orientation requests to use `recordCount` instead of `labels`.