### PR TITLE
Ryan headless fix

### DIFF
--- a/lib/paraapi/paraapi.ts
+++ b/lib/paraapi/paraapi.ts
@@ -16,7 +16,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.*/
 
 import { type Datapoint } from '@fizz/paramodel';
 
-import { ORIENTATION_SENTENCES, type BaseChartInfo } from '../chart_types';
+import { ORIENTATION_SENTENCES, PASTRY_ORIENTATION_SENTENCES, type BaseChartInfo } from '../chart_types';
 import { type ParaChart } from '../parachart/parachart';
 import { Direction, makeSequenceId, Setting, SettingsManager } from '../state';
 import { ActionArgumentMap, AvailableActions } from '../state/action_map';
@@ -276,7 +276,11 @@ export class ParaAPI {
   }
 
   async getAltText(): Promise<string | undefined> {
-    const summary = await this.paraChart.paraView.documentView!.chartInfo.summarizer.getRequestedSummaries(ORIENTATION_SENTENCES);
+    const chartType = this._paraChart.paraState.type;
+    const orientationSentences = ['pie', 'donut', 'gauge'].includes(chartType) 
+      ? PASTRY_ORIENTATION_SENTENCES 
+      : ORIENTATION_SENTENCES;
+    const summary = await this.paraChart.paraView.documentView!.chartInfo.summarizer.getRequestedSummaries(orientationSentences);
     return summary?.text;
   }
 

--- a/lib/parachart/parachart.ts
+++ b/lib/parachart/parachart.ts
@@ -137,8 +137,8 @@ export class ParaChart extends ParaComponent {
     });
     this._readyPromise = new Promise((resolve) => {
       this.addEventListener('paraviewready', async () => {
-        resolve();
         await initParaSummary();
+        resolve();
         // It's now safe to load a manifest
         // In headless mode, loadManifest() handles loading via willUpdate, so skip here
         if (this.manifest && !this.headless) {


### PR DESCRIPTION
- Fixes altText getter in API, using different orientation sentences depending on if we're in a pastry chart or a plane chart
- Fixes race condition in parachart constructor