### PR TITLE
Fixed trendlines and axes intervals

### DIFF
--- a/lib/chart_types/plane_chart.ts
+++ b/lib/chart_types/plane_chart.ts
@@ -85,17 +85,15 @@ export abstract class PlaneChartInfo extends BaseChartInfo {
 
   protected _init(): void {
     super._init();
-    const indepFacetKey = this._paraState.model!.independentFacetKeys[0];
-    const indepFacet = this._paraState.model!.getFacet(indepFacetKey)!;
-    const depFacetKey = this._paraState.model!.dependentFacetKeys[0];
-    const depFacet = this._paraState.model!.getFacet(depFacetKey)!;
+    const indepFacet = this._paraState.model!.getFacet("x")!;
+    const depFacet = this._paraState.model!.getFacet("y")!;
     if (indepFacet.datatype === 'number') {
-      this._xInterval = this._numericXAxisRange(indepFacetKey);
+      this._xInterval = this._numericXAxisRange("x");
     } else {
       this._xInterval = null;
     }
     if (depFacet.datatype === 'number') {
-      this._yInterval = this._numericYAxisRange(depFacetKey);
+      this._yInterval = this._numericYAxisRange("y");
     } else {
       this._yInterval = null;
     }

--- a/lib/view/layers/data/chart_type/scatter_plot_view.ts
+++ b/lib/view/layers/data/chart_type/scatter_plot_view.ts
@@ -16,6 +16,7 @@ import { Popup } from '../../../popup';
 export class ScatterPlotView extends PointPlotView {
   declare protected _chartInfo: ScatterChartInfo;
   protected _types = new DataSymbols().types;
+  protected _trendLine?: ScatterTrendLineView;
   datapointViewsStatic?: ScatterPointView[];
 
   protected _clusterShellView: ClusterShellView | null = null;
@@ -92,6 +93,22 @@ export class ScatterPlotView extends PointPlotView {
     }
   }
 
+  protected _completeDatapointLayout(): void {
+    super._completeDatapointLayout();
+    if (this._trendLine) {
+      this._trendLine.remove();
+    }
+    const trendLine = new ScatterTrendLineView(this);
+    this._trendLine = trendLine;
+    this.append(trendLine);
+  }
+
+  noticePosted(key: string, value: any): void {
+    if (['animRevealEnd'].includes(key)) {
+      this._completeDatapointLayout();
+    }
+  }
+
   updateOutliers() {
     for (let datapoint of this.datapointViews) {
       if (datapoint.isOutlier) {
@@ -111,13 +128,6 @@ export class ScatterPlotView extends PointPlotView {
     }
     return super.content(...options);
   }
-
-  protected _animEnd() {
-    super._animEnd()
-    const trendLine = new ScatterTrendLineView(this);
-    this.append(trendLine);
-  }
-
 }
 
 class ScatterPointView extends PointDatapointView {
@@ -133,15 +143,6 @@ class ScatterPointView extends PointDatapointView {
       / (xInterval.end - xInterval.start);
     const parentWidth: number = this.chart.parent.width;
     return parentWidth * xTemp;
-  }
-
-  get width() {
-    if (this._symbol?.width!) {
-      return 2 * 1.5 * this._symbol!.width
-    }
-    else {
-      return 36
-    }
   }
 
   protected _createShape(): void {


### PR DESCRIPTION
Trendlines now appear whether animation is turned on or off
`xInterval` now calculates values using the 'x' facet rather than the dependent facet. This fixes the iris dataset not working due to points being offscreen