### PR TITLE
Popup bug fixes

### DIFF
--- a/lib/view/layers/data/data_layer.ts
+++ b/lib/view/layers/data/data_layer.ts
@@ -159,13 +159,11 @@ export abstract class DataLayer extends PlotLayer {
       }
     }
     if (['popup.activation'].includes(path)) {
-      if (oldValue === "onSelect" || oldValue === "onFocus") {
-        this.paraview.paraState.clearPopups();
-        this.paraview.paraState.userLineBreaks.splice(0, this.paraview.paraState.userLineBreaks.length);
-      }
+      this.paraview.paraState.clearPopups();
+      this.paraview.paraState.userLineBreaks.splice(0, this.paraview.paraState.userLineBreaks.length);
     }
     if (['chart.isShowPopups'].includes(path)) {
-      this.paraview.paraState.popups.splice(0, this.paraview.paraState.popups.length)
+      this.paraview.paraState.clearPopups();
     }
     super.settingDidChange(path, oldValue, newValue);
   }


### PR DESCRIPTION
-Opening low-vision mode while a cursor popup is active no longer throws errors
-Focus/select popups disappear when switching popup modes.