### PR TITLE
Adds direct support for `HighlightedSummary` in `ParaCaptionBox`

### DIFF
--- a/lib/control_panel/caption.ts
+++ b/lib/control_panel/caption.ts
@@ -187,29 +187,6 @@ export class ParaCaptionBox extends ParaComponent {
     }
   }
 
-  getHighlightedSummary(): HighlightedSummary {
-    const highlights: Highlight[] = [];
-    const article = this._captionRef.value!.firstElementChild!;
-    let total = 0;
-    for (const span of article.children) {
-      const text = span.textContent;
-      highlights.push({
-        start: total,
-        end: total + text.length,
-        phrasecode: (span as HTMLElement).dataset.phrasecode!
-      });
-      if ((span as HTMLElement).dataset.action) {
-        highlights.at(-1)!.action = (span as HTMLElement).dataset.action;
-      }
-      total += text.length;
-    }
-    return {
-      text: article.textContent.trim(),
-      html: article.innerHTML,
-      highlights
-    }
-  }
-
   renderSummary(summary: HighlightedSummary | string, idPrefix: string): TemplateResult {
     if (typeof summary === 'string') {
       summary = { text: summary, html: summary };

--- a/lib/paraview/paraview.ts
+++ b/lib/paraview/paraview.ts
@@ -630,7 +630,7 @@ export class ParaView extends ParaComponent {
           draft.ui.isVoicingEnabled = true;
         });
       }
-      this._paraState.announce(this.paraChart.captionBox.getHighlightedSummary());
+      this._paraState.announce(this.paraChart.captionBox.caption);
     } else {
       this.ariaLiveRegion.voicing.speak('Tour guide disabled.', []);
       this.paraChart.captionBox.clearSpanHighlights();

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fizz/logger": "^0.1.0",
         "@fizz/paramanifest": "^0.11.2",
         "@fizz/paramodel": "^0.6.23",
-        "@fizz/parasummary": "^0.12.0",
+        "@fizz/parasummary": "^0.12.1",
         "@fizz/sparkbraille-component": "^0.5.0",
         "@fizz/templum": "^0.4.4",
         "@fizz/ui-components": "^0.70.5",
@@ -2108,9 +2108,9 @@
       }
     },
     "node_modules/@fizz/parasummary": {
-      "version": "0.12.0",
-      "resolved": "https://npm.fizz.studio/@fizz/parasummary/-/parasummary-0.12.0.tgz",
-      "integrity": "sha512-peYssSFtzdA5j9BjyBO5FXJBrNbHpivPSynS7OXjR/VuJc5WnBfaHS55TrroBoznuBrhnL1elnHAt3BrscZwoA==",
+      "version": "0.12.1",
+      "resolved": "https://npm.fizz.studio/@fizz/parasummary/-/parasummary-0.12.1.tgz",
+      "integrity": "sha512-k1+SL7WR93Z/5HgRjTxX/wM5LabNxWZI1m5GnmKoLuvukaNBl2+gx14tiyhZGABm/5P7Tb4qjOEbRm4BSowl5g==",
       "license": "UNLICENSED",
       "dependencies": {
         "@fizz/chart-classifier-utils": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@fizz/logger": "^0.1.0",
     "@fizz/paramanifest": "^0.11.2",
     "@fizz/paramodel": "^0.6.23",
-    "@fizz/parasummary": "^0.12.0",
+    "@fizz/parasummary": "^0.12.1",
     "@fizz/sparkbraille-component": "^0.5.0",
     "@fizz/templum": "^0.4.4",
     "@fizz/ui-components": "^0.70.5",

--- a/src/stories/descriptionOverride.stories.ts
+++ b/src/stories/descriptionOverride.stories.ts
@@ -15,7 +15,7 @@ export default meta;
 export const DescriptionOverride: Story = {
   args: {
     filename: 'manifests/autogen/line-single/line-single-manifest-843.json',
-    description: 'An unrelated description'
+    description: 'Unrelated <span data-action=\"getSeries(\'Revenue in million U.S. dollars\').getPoints(0).highlight()\" data-phrasecode=\"0\">description</span><span data-action=\"getSeries(\'Revenue in million U.S. dollars\').getPoints(1).highlight()\" data-phrasecode="1">.</span>'
   },
   play: async ({ canvas, userEvent }) => {
     const parachart = await canvas.findByTestId('para-chart');


### PR DESCRIPTION
Removes `getHighlightedSummary` from `ParaCaptionBox` as the highlighted summary can now be read directly from `ParaCaptionBox.caption`. Closes #1103