### PR TITLE
Fix jimIndex in createId

### DIFF
--- a/lib/view/data/datapoint.ts
+++ b/lib/view/data/datapoint.ts
@@ -210,7 +210,11 @@ export class DatapointView extends DataView {
   }
 
   protected _createId(..._args: any[]): string {
-    const jimIndex = this._parent.modelIndex * this._series.length + this.index + 1;
+    let jimIndex = 1;
+    for (let i = this._parent.modelIndex - 1; i == 0; i--) {
+      jimIndex += this.paraview.paraState.model?.series[i].datapoints.length!
+    }
+    jimIndex += this.index;
     const id = (this.paraview.paraState.jimerator!.manifest.jim as any).selectors[`datapoint${jimIndex}`].dom as string;
     // don't include the '#' from JIM
     return id.slice(1);


### PR DESCRIPTION
Overall datapoint index is now calculated correctly in `Datapoint._createID()`
Fixes https://github.com/fizzstudio/ParaCharts/issues/1252