### PR TITLE
Low vis changes

### DIFF
--- a/etc/paracharts.api.md
+++ b/etc/paracharts.api.md
@@ -5,9 +5,8 @@
 ```ts
 
 import { AllSeriesData } from '@fizz/paramanifest';
-import { AxisOrientation } from '@fizz/paramodel';
 import { ButtonDescriptor } from '@fizz/ui-components';
-import { ChartType as ChartType_2 } from '@fizz/paramanifest';
+import { ChartType as ChartType_3 } from '@fizz/paramanifest';
 import { ClassInfo } from 'lit/directives/class-map.js';
 import { ClassInfo as ClassInfo_2 } from 'lit-html/directives/class-map.js';
 import { clusterObject } from '@fizz/clustering';
@@ -79,19 +78,9 @@ export type AnimationType = 'yAxis' | 'xAxis' | 'none';
 // @public (undocumented)
 export interface AxesSettings extends SettingGroup {
     datapointMargin: number;
-    horiz: OrientedAxisSettings<'horiz'>;
     minInterval: number;
-    vert: OrientedAxisSettings<'vert'>;
     x: XAxisSettings;
     y: YAxisSettings;
-}
-
-// @public (undocumented)
-export interface AxisLineSettings extends SettingGroup {
-    isDrawAxisLine: boolean;
-    isDrawOverhang: boolean;
-    strokeLinecap: string;
-    strokeWidth: number;
 }
 
 // @public (undocumented)
@@ -99,16 +88,6 @@ export interface AxisSettings extends SettingGroup {
     interval: number | 'unset';
     maxValue: number | 'unset';
     minValue: number | 'unset';
-}
-
-// @public (undocumented)
-export interface AxisTitleSettings extends SettingGroup {
-    align?: 'start' | 'middle' | 'end';
-    fontSize: string;
-    gap: number;
-    isDrawTitle?: boolean;
-    position?: 'top' | 'bottom';
-    text?: string;
 }
 
 // @public
@@ -141,13 +120,6 @@ export interface BarSettings extends PlaneChartSettings {
 }
 
 // @public
-export type BoxStyle = {
-    outline: Color;
-    outlineWidth: number;
-    fill: Color;
-};
-
-// @public
 export function buildManifestFromCsv(input: ManifestBuilderInput): Manifest;
 
 // @public (undocumented)
@@ -159,33 +131,6 @@ export interface CaptionBoxSettings extends SettingGroup {
 
 // @public
 export type CardinalDirection = VertCardinalDirection | HorizCardinalDirection;
-
-// @public (undocumented)
-export interface ChartSettings extends SettingGroup {
-    directLabelFontSize: string;
-    extremumWeight: number;
-    fontFamily: string;
-    fontScale: number;
-    fontWeight: string;
-    hasDirectLabels: boolean;
-    hasLegendWithDirectLabels: boolean;
-    isDrawSymbols: boolean;
-    isShowPopups: boolean;
-    isShowVisitedDatapointsOnly: boolean;
-    isStatic: boolean;
-    maxError: number;
-    maxSegments: number;
-    orientation: CardinalDirection;
-    padding: string;
-    size: Size2d;
-    stroke: string;
-    strokeHighlightScale: number;
-    strokeWidth: number;
-    symbolHighlightScale: number;
-    symbolStrokeWidth: number;
-    title: TitleSettings;
-    type: ChartType;
-}
 
 // @public
 export type ChartType = XYChartType | RadialChartType;
@@ -308,14 +253,6 @@ export const FORMAT_CONTEXT_SETTINGS: {
 // @public
 export type FormatContext = keyof typeof FORMAT_CONTEXT_SETTINGS;
 
-// @public
-export interface GridSettings extends SettingGroup {
-    isDrawHorizAxisOppositeLine: boolean;
-    isDrawHorizLines: boolean;
-    isDrawVertAxisOppositeLine: boolean;
-    isDrawVertLines: boolean;
-}
-
 // @public (undocumented)
 export interface HeatmapSettings extends PointSettings {
     resolution: number;
@@ -348,28 +285,11 @@ export type LabelFormat = 'raw' | string;
 
 // @public (undocumented)
 export interface LabelSettings extends SettingGroup {
+    // Warning: (ae-forgotten-export) The symbol "Color" needs to be exported by the entry point index.d.ts
     color: Color;
     fontSize: number;
     isDrawEnabled: boolean;
     margin: number;
-}
-
-// @public
-export type LegendItemOrder = 'alphabetical' | 'series';
-
-// @public (undocumented)
-export interface LegendSettings extends SettingGroup {
-    boxStyle: BoxStyle;
-    fontSize: string;
-    isAlwaysDrawLegend: boolean;
-    isDrawLegend: boolean;
-    isDrawLegendWhenNeeded: boolean;
-    itemOrder: LegendItemOrder;
-    margin: number;
-    padding: number;
-    pairGap: number;
-    position: CardinalDirection;
-    symbolLabelGap: number;
 }
 
 // @public (undocumented)
@@ -451,18 +371,6 @@ export interface ManifestBuilderInput {
 }
 
 // @public
-export interface OrientedAxisSettings<T extends AxisOrientation> extends SettingGroup {
-    isDrawAxis: boolean;
-    isStaggerLabels: boolean;
-    isWrapLabels: boolean;
-    labelOrder: T extends 'horiz' ? 'westToEast' | 'eastToWest' : 'southToNorth' | 'northToSouth';
-    line: AxisLineSettings;
-    position: T extends 'horiz' ? VertCardinalDirection : HorizCardinalDirection;
-    ticks: TickSettings;
-    title: AxisTitleSettings;
-}
-
-// @public
 export class ParaAPI {
     constructor(_paraChart: ParaChart);
     // (undocumented)
@@ -473,8 +381,7 @@ export class ParaAPI {
     protected _actions: Actions;
     // (undocumented)
     addCrosshair(xAxis: string | number, yAxis: string | number): void;
-    // (undocumented)
-    addRecord(points: Record<string, {
+    addRecord(pushPoints: Record<string, {
         x: string;
         y: string;
     }>): Promise<void>;
@@ -560,6 +467,10 @@ export class ParaAPI {
     protected _paraChart: ParaChart;
     // (undocumented)
     refresh(): void;
+    removeRecord(unshiftPoints: Record<string, {
+        x: string;
+        y: string;
+    }>): Promise<void>;
     // (undocumented)
     removeTrendLine(): void;
     serializeChart(): string;
@@ -571,6 +482,11 @@ export class ParaAPI {
     setSettings(settingsInput: SettingsInput): void;
     setSize(width: number, height: number): void;
     setWidth(width: number): void;
+    // (undocumented)
+    protected _slideWindow(points: Record<string, {
+        x: string;
+        y: string;
+    }>, forward?: boolean): Promise<void>;
     // (undocumented)
     protected _standardActions: Actions;
     // (undocumented)
@@ -624,7 +540,7 @@ export class ParaChart extends ParaComponent {
     // (undocumented)
     protected firstUpdated(_changedProperties: PropertyValues): void;
     // (undocumented)
-    accessor forcecharttype: ChartType_2 | undefined;
+    accessor forcecharttype: ChartType_3 | undefined;
     // (undocumented)
     headless: boolean;
     // (undocumented)
@@ -702,7 +618,7 @@ export class ParaChart extends ParaComponent {
     // (undocumented)
     protected _tourBus: TourBus;
     // (undocumented)
-    type?: ChartType_2;
+    type?: ChartType_3;
     // (undocumented)
     waitForManifest(): Promise<void>;
     // (undocumented)
@@ -814,13 +730,10 @@ export type SettingGroup = {
 export interface Settings extends SettingGroup {
     animation: AnimationSettings;
     axis: AxesSettings;
-    chart: ChartSettings;
     controlPanel: ControlPanelSettings;
     dataTable: DataTableSettings;
     dev: DevSettings;
-    grid: GridSettings;
     jim: JimSettings;
-    legend: LegendSettings;
     plotArea: PlotAreaSettings;
     popup: PopupSettings;
     scrollytelling: ScrollytellingSettings;
@@ -850,29 +763,6 @@ export interface StepLineSettings extends PointSettings {
 
 // @public
 export type TabLabelStyle = 'icon' | 'iconLabel' | 'label';
-
-// @public (undocumented)
-export interface TickLabelSettings extends SettingGroup {
-    angle: number;
-    fontSize: string;
-    gap: number;
-    isDrawTickLabels: boolean;
-    offsetGap: number;
-}
-
-// @public (undocumented)
-export interface TickSettings extends SettingGroup {
-    isDrawTicks?: boolean;
-    isOnDatapoint: boolean;
-    labelFormat: LabelFormat;
-    labels: TickLabelSettings;
-    length: number;
-    opacity: number;
-    padding: number;
-    step: number;
-    strokeLinecap: string;
-    strokeWidth: number;
-}
 
 // @public (undocumented)
 export interface TitleSettings extends SettingGroup {
@@ -935,10 +825,6 @@ export type XYChartType = 'bar' | 'lollipop' | PointChartType;
 // @public
 export interface YAxisSettings extends AxisSettings {
 }
-
-// Warnings were encountered during analysis:
-//
-// types/state/settings_types.d.ts:45:5 - (ae-forgotten-export) The symbol "Color" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/lib/view/axis/rule.ts
+++ b/lib/view/axis/rule.ts
@@ -75,6 +75,7 @@ export abstract class AxisRule extends View {
         id=${this.darken ? 'grid-zero' : ''}
         class=${classMap(this.classInfo)}
         d=${move + ' ' + line}
+        stroke-width=${this.paraview.paraState.config.ui.isLowVisionModeEnabled ? 3 : 1}
       ></path>
     `;
   }

--- a/lib/view/data/datapoint.ts
+++ b/lib/view/data/datapoint.ts
@@ -289,8 +289,8 @@ export class DatapointView extends DataView {
     // If datapoints are laid out again after the initial layout,
     // we need to replace the original shape and symbol
     this._symbol?.remove();
-    const blackBorders = this.paraview.paraState.config.ui.isLowVisionModeEnabled;
-    this._symbol = DataSymbol.fromType(this.paraview, symbolType, {blackBorder: blackBorders, borderStrokeWidth: 3});
+    this._symbol = DataSymbol.fromType(this.paraview, symbolType,
+      { blackBorder: this.paraview.paraState.config.ui.isLowVisionModeEnabled, borderStrokeWidth: 3 });
     this.append(this._symbol);
   }
 

--- a/lib/view/data/datapoint.ts
+++ b/lib/view/data/datapoint.ts
@@ -210,7 +210,11 @@ export class DatapointView extends DataView {
   }
 
   protected _createId(..._args: any[]): string {
-    const jimIndex = this._parent.modelIndex * this._series.length + this.index + 1;
+    let jimIndex = 1;
+    for (let i = this._parent.modelIndex - 1; i == 0; i--) {
+      jimIndex += this.paraview.paraState.model?.series[i].datapoints.length!
+    }
+    jimIndex += this.index;
     const id = (this.paraview.paraState.jimerator!.manifest.jim as any).selectors[`datapoint${jimIndex}`].dom as string;
     // don't include the '#' from JIM
     return id.slice(1);
@@ -285,7 +289,8 @@ export class DatapointView extends DataView {
     // If datapoints are laid out again after the initial layout,
     // we need to replace the original shape and symbol
     this._symbol?.remove();
-    this._symbol = DataSymbol.fromType(this.paraview, symbolType);
+    const blackBorders = this.paraview.paraState.config.ui.isLowVisionModeEnabled;
+    this._symbol = DataSymbol.fromType(this.paraview, symbolType, {blackBorder: blackBorders, borderStrokeWidth: 3});
     this.append(this._symbol);
   }
 

--- a/lib/view/direct_label_strip.ts
+++ b/lib/view/direct_label_strip.ts
@@ -243,6 +243,7 @@ class LineLabelLeader extends View {
       this.paraview.paraState.seriesProperties!.properties(this._seriesKey).color);
     styles.fill = colorValue;
     styles.stroke = colorValue;
+    styles.strokeWidth = this.paraview.paraState.config.ui.isLowVisionModeEnabled ? 6 : 2;
     return styles;
   }
 

--- a/lib/view/layers/data/chart_type/line_plot_view.ts
+++ b/lib/view/layers/data/chart_type/line_plot_view.ts
@@ -155,16 +155,6 @@ export class LineSection extends PointDatapointView {
     super.completeLayout();
   }
 
-  protected _createSymbol() {
-    const series = this.seriesProps;
-    let symbolType = series.symbol;
-    // If datapoints are laid out again after the initial layout,
-    // we need to replace the original shape and symbol
-    this._symbol?.remove();
-    this._symbol = DataSymbol.fromType(this.paraview, symbolType);
-    this.append(this._symbol);
-  }
-
   protected _computePrev() {
     this._prevMidX = -this.width / 2; // - 0.1;
     this._prevMidY = (this._prev!.y - this.y) / 2;

--- a/lib/view/layers/data/chart_type/point_plot_view.ts
+++ b/lib/view/layers/data/chart_type/point_plot_view.ts
@@ -21,7 +21,7 @@ import { Setting, type PointChartType } from '../../../../state/settings_types';
 
 import { enumerate } from '@fizz/paramodel';
 import { formatBox } from '@fizz/parasummary';
-import { svg, TemplateResult } from 'lit';
+import { svg } from 'lit';
 import { linearRegression } from '@fizz/simple-statistics';
 import { View } from '../../../base_view';
 import { strToId } from '@fizz/paramanifest';
@@ -136,18 +136,7 @@ export abstract class PointPlotView extends PlanePlotView {
 }
 
 export class PointSeriesView extends PlaneSeriesView {
-  renderChildren(): TemplateResult {
-    const childrenSymbols = this.children.map(kid => kid.symbol).flat().filter(s => s!==null)
-    //console.log(childrenSymbols);
-    return svg`${[...this.children, ...childrenSymbols].map(kid => {
-      //console.log(kid)
-      return kid.render({renderChildren: false})
-    })}`;
-    
-    return svg`${this.children.map(kid => {
-      //console.log(kid)
-      return kid.render()})}`;
-  }
+
 }
 
 

--- a/lib/view/layers/data/chart_type/point_plot_view.ts
+++ b/lib/view/layers/data/chart_type/point_plot_view.ts
@@ -21,7 +21,7 @@ import { Setting, type PointChartType } from '../../../../state/settings_types';
 
 import { enumerate } from '@fizz/paramodel';
 import { formatBox } from '@fizz/parasummary';
-import { svg } from 'lit';
+import { svg, TemplateResult } from 'lit';
 import { linearRegression } from '@fizz/simple-statistics';
 import { View } from '../../../base_view';
 import { strToId } from '@fizz/paramanifest';
@@ -136,7 +136,18 @@ export abstract class PointPlotView extends PlanePlotView {
 }
 
 export class PointSeriesView extends PlaneSeriesView {
-
+  renderChildren(): TemplateResult {
+    const childrenSymbols = this.children.map(kid => kid.symbol).flat().filter(s => s!==null)
+    //console.log(childrenSymbols);
+    return svg`${[...this.children, ...childrenSymbols].map(kid => {
+      //console.log(kid)
+      return kid.render({renderChildren: false})
+    })}`;
+    
+    return svg`${this.children.map(kid => {
+      //console.log(kid)
+      return kid.render()})}`;
+  }
 }
 
 

--- a/lib/view/layers/focus/focus_ring.ts
+++ b/lib/view/layers/focus/focus_ring.ts
@@ -37,7 +37,17 @@ export class FocusRing extends Container(View) {
         y,
         width,
         height,
-        stroke: 'white',
+        stroke: 'yellow',
+        strokeWidth: 1,
+        fill: 'yellow',
+        opacity: .3
+      }));
+      this.append(new RectShape(paraview, {
+        x,
+        y,
+        width,
+        height,
+        stroke: 'yellow',
         strokeWidth: strokeWidthOuter,
         fill: 'none'
       }));

--- a/lib/view/layers/focus/focus_ring.ts
+++ b/lib/view/layers/focus/focus_ring.ts
@@ -38,16 +38,6 @@ export class FocusRing extends Container(View) {
         width,
         height,
         stroke: 'yellow',
-        strokeWidth: 1,
-        fill: 'yellow',
-        opacity: .3
-      }));
-      this.append(new RectShape(paraview, {
-        x,
-        y,
-        width,
-        height,
-        stroke: 'yellow',
         strokeWidth: strokeWidthOuter,
         fill: 'none'
       }));

--- a/lib/view/symbol.ts
+++ b/lib/view/symbol.ts
@@ -107,6 +107,8 @@ export interface DataSymbolOptions {
   dashed: boolean;
   lighten?: boolean;
   isClip?: boolean;
+  blackBorder?: boolean;
+  borderStrokeWidth: number;
   pointerEnter?: (e: PointerEvent) => void;
   pointerLeave?: (e: PointerEvent) => void;
 }
@@ -157,6 +159,8 @@ export class DataSymbol extends View {
       dashed: options?.dashed ?? false,
       lighten: options?.lighten ?? false,
       isClip: options?.isClip ?? false,
+      blackBorder: options?.blackBorder ?? false,
+      borderStrokeWidth: options?.borderStrokeWidth ?? 1,
       pointerEnter: options?.pointerEnter,
       pointerLeave: options?.pointerLeave
     };
@@ -311,6 +315,15 @@ export class DataSymbol extends View {
     }
   }
 
+  protected _blackBorderStyleInfo() {
+    return {
+      stroke: 'black',
+      strokeWidth: this._options.strokeWidth + this._options.borderStrokeWidth,
+      fill: 'none',
+      pointerEvents: 'none'
+    };
+  }
+
   content() {
     let transform;
     let shouldTransform = false;
@@ -319,13 +332,22 @@ export class DataSymbol extends View {
       transform = fixed`translate(${this._x},${this._y})`;
       transform += fixed` scale(${this._options.scale})`;
     }
-    let type = this.paraview.paraState.type
     if (this.parent instanceof DatapointView){
       if (this._y < 0 || this._y > this.parent.chart.parent.logicalHeight){
         this.hidden = true;
       }
     }
     return this.hidden ? svg`` : svg`
+      ${this._options.blackBorder ? svg`
+        <use
+          href="#${this._defsKey}"
+          style=${styleMap(this._blackBorderStyleInfo())}
+          transform=${shouldTransform ? transform : nothing}
+          x=${shouldTransform ? nothing : this._x}
+          y=${shouldTransform ? nothing : this._y}
+          clip-path=${nothing}
+        />
+      ` : nothing}
       <use
         href="#${this._defsKey}"
         id=${this._id || nothing}


### PR DESCRIPTION
Per https://github.com/fizzstudio/ParaCharts/issues/814
In low vision mode:
-Grid lines thicken
-Leader lines thicken
-Focus ring has a yellow outline
-Symbols have a black border to distinguish them from the surrounding line

-Removed duplicate overloaded function `_createSymbol` in `LineSection`