### PR TITLE
Provisional fix to tour guide

### DIFF
--- a/lib/state/parastate.ts
+++ b/lib/state/parastate.ts
@@ -389,6 +389,7 @@ export class ParaState extends BaseState {
     const hydratedConfig = SettingsManager.hydrateInput(inputSettings) as Partial<Config>;
     SettingsManager.suppleteSettings(hydratedConfig, defaultConfig);
     this.config = hydratedConfig as Config;
+    SettingsManager.suppleteSettings(this.settings, this.config as unknown as Settings);
   }
 
   protected _syncPatchesToManifest(patches: Patch[]) {


### PR DESCRIPTION
Intended to fix the issue with narrative highlights mentioned by Charlotte on Friday. 
The bug stems from a formatting function calling `ParaState.getFormatType()` which calls the `SettingsManager`. Currently both `ParaState.settings` and `Parastate.config` have non-overlapping axis settings, and the relevant setting is in `config` while the `SettingsManager` only tracks `settings`. The simple solution is to supplete `settings` with `config`, so any settings/groups in the process of being moved can still be used by SettingsManager until the settings infrastructure is eventually replaced completely (and this does fix the tour guide bug). I'm not familiar with these ongoing changes, so let me know if you foresee this causing any unintended problems.